### PR TITLE
LUN-191: Rename module "Modul" to "Beruf"

### DIFF
--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -1,8 +1,8 @@
 {
   "home": {
     "welcome": "Willkommen bei Lunes!\nLerne Vokabeln für deinen Beruf.",
-    "unit": "Modul",
-    "units": "Module",
+    "unit": "Beruf",
+    "units": "Berufe",
     "word": "Wort",
     "words": "Wörter",
     "exercises": "Übungen",


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.
