### PR TITLE
LUN-214: Missing connection when adding discipline

### DIFF
--- a/release-notes/unreleased/LUN-214-Missing-Connection-Adding-Discipline.yml
+++ b/release-notes/unreleased/LUN-214-Missing-Connection-Adding-Discipline.yml
@@ -1,0 +1,5 @@
+issue_key: LUN-214
+show_in_stores: true
+platforms:
+  - ios
+de: Fehler beim Hinzufügen individueller Bereiche behoben

--- a/release-notes/unreleased/LUN-214-Missing-Connection-Adding-Discipline.yml
+++ b/release-notes/unreleased/LUN-214-Missing-Connection-Adding-Discipline.yml
@@ -1,5 +1,0 @@
-issue_key: LUN-214
-show_in_stores: true
-platforms:
-  - ios
-de: Fehler beim Hinzufügen individueller Bereiche behoben

--- a/src/hooks/__tests__/useLoadFromEndpoint.spec.ts
+++ b/src/hooks/__tests__/useLoadFromEndpoint.spec.ts
@@ -21,7 +21,7 @@ describe('getFromEndpoint', () => {
     const responseData = await getFromEndpoint(url)
     expect(responseData).toBe(data)
     expect(axios.get).toHaveBeenCalledTimes(1)
-    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc', { headers: {} })
+    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc/', { headers: {} })
   })
 
   it('should include api key in header', async () => {
@@ -34,7 +34,7 @@ describe('getFromEndpoint', () => {
     const apiKey = 'my_api_key'
     await getFromEndpoint(url, apiKey)
     expect(axios.get).toHaveBeenCalledTimes(1)
-    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc', {
+    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc/', {
       headers: { Authorization: `Api-Key ${apiKey}` }
     })
   })

--- a/src/routes/AddCustomDisciplineScreen.tsx
+++ b/src/routes/AddCustomDisciplineScreen.tsx
@@ -42,6 +42,7 @@ const StyledTextInput = styled.TextInput<{ errorMessage: string }>`
   border-radius: 4px;
   margin-top: ${hp('8%')}px;
   padding-left: 15px;
+  height: ${hp('8%')}px;
 `
 
 const ErrorContainer = styled.View`

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,10 +1,12 @@
 import axios from 'axios'
 
+import { addTrailingSlashToUrl } from './helpers'
+
 const baseURL = __DEV__ ? 'https://lunes-test.tuerantuer.org/api' : 'https://lunes.tuerantuer.org/api'
 
 export const getFromEndpoint = async <T>(url: string, apiKey?: string): Promise<T> => {
   const headers = apiKey ? { Authorization: `Api-Key ${apiKey}` } : {}
-  const response = await axios.get(`${baseURL}/${url}`, { headers })
+  const response = await axios.get(`${baseURL}/${addTrailingSlashToUrl(url)}`, { headers })
   return response.data
 }
 

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -33,5 +33,5 @@ export const moveToEnd = <T>(array: T[], index: number): T[] => {
 
 // fix ios issue for Django, that requires trailing slash in request url https://github.com/square/retrofit/issues/1037
 export const addTrailingSlashToUrl = (url: string): string => {
-  return url.lastIndexOf('/') !== -1 ? url : `${url}/`
+  return url.endsWith('/') ? url : `${url}/`
 }

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -30,3 +30,8 @@ export const moveToEnd = <T>(array: T[], index: number): T[] => {
   newDocuments.push(currDocument)
   return newDocuments
 }
+
+// fix ios issue for Django, that requires trailing slash in request url https://github.com/square/retrofit/issues/1037
+export const addTrailingSlashToUrl = (url: string): string => {
+  return url.lastIndexOf('/') !== -1 ? url : `${url}/`
+}


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

Please test this issue on IOS!

Probably its not the best way to fix it on FE. We can discuss better ways
Maybe we should just check the Apache Logs.
Feel free to discuss