### PR TITLE
LUN-235: Fix back navigation in resultscreen

### DIFF
--- a/release-notes/unreleased/LUN-235-fix-back-navigation-in-resultscreen.yml
+++ b/release-notes/unreleased/LUN-235-fix-back-navigation-in-resultscreen.yml
@@ -1,0 +1,6 @@
+issue_key: LUN-235
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Navigationsbug behoben

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -146,9 +146,7 @@ const Navigator = (): JSX.Element => {
           component={ResultsOverviewScreen}
         />
         <Stack.Screen
-          options={({ navigation }) =>
-            defaultOptions(labels.results.resultsOverview, BackButton, navigation, false, 'ResultsOverview')
-          }
+          options={({ navigation }) => defaultOptions(labels.results.resultsOverview, BackButton, navigation, false)}
           name='ResultScreen'
           component={ResultScreen}
         />


### PR DESCRIPTION
I think just use the goBack functionality should do the trick. Don't know why we need here an explicit screen.
I hope i haven't overseen anything