### PR TITLE
LUN-197: Resize app screen for tablets

### DIFF
--- a/ios/Lunes.xcodeproj/project.pbxproj
+++ b/ios/Lunes.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match Development app.lunes";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -595,6 +596,7 @@
 				PRODUCT_NAME = Lunes;
 				PROVISIONING_PROFILE_SPECIFIER = "match Development app.lunes";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/release-notes/unreleased/LUN-197-resize-app-screen-for-tablets.yml
+++ b/release-notes/unreleased/LUN-197-resize-app-screen-for-tablets.yml
@@ -1,0 +1,5 @@
+issue_key: LUN-197
+show_in_stores: true
+platforms:
+  - ios
+de: Support für iPads hinzugefügt.


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

Finally we can all use lunes on our iPads /play sexyback

![image](https://user-images.githubusercontent.com/37902063/151987009-b0e62810-689b-48a5-bc8d-6b38546ce2ac.png)
