### PR TITLE
LUN-247: Create reusable styled components for texts

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,6 +5,7 @@ import styled, { css, useTheme } from 'styled-components/native'
 
 import { BUTTONS_THEME, ButtonTheme } from '../constants/data'
 import { Color } from '../constants/theme/colors'
+import { Subheading } from './text/Subheading'
 
 interface ThemedButtonProps {
   buttonTheme: ButtonTheme
@@ -35,14 +36,11 @@ const ThemedButton = styled.TouchableOpacity<ThemedButtonProps>`
   background-color: ${props => props.backgroundColor};
 `
 
-const Label = styled.Text<ThemedLabelProps>`
+const Label = styled(Subheading)<ThemedLabelProps>`
   color: ${props => props.color};
   text-align: center;
-  font-family: ${props => props.theme.fonts.contentFontBold};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
   letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
   text-transform: uppercase;
-  font-weight: ${props => props.theme.fonts.defaultFontWeight};
   padding: ${props => `0 ${props.theme.spacings.xs}`};
 `
 

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -34,6 +34,7 @@ const Message = styled(HeadingText)`
   width: ${wp('60%')}px;
   margin-bottom: ${props => props.theme.spacings.lg};
   padding-top: ${props => props.theme.spacings.lg};
+  text-align: center;
 `
 
 export interface ConfirmationModalProps {

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/native'
 import { CloseIcon } from '../../assets/images'
 import { BUTTONS_THEME } from '../constants/data'
 import Button from './Button'
+import { HeadingText } from './text/Heading'
 
 const Overlay = styled.View`
   flex: 1;
@@ -29,11 +30,7 @@ const Icon = styled.TouchableOpacity`
   width: ${wp('6%')}px;
   height: ${wp('6%')}px;
 `
-const Message = styled.Text`
-  text-align: center;
-  font-size: ${props => props.theme.fonts.headingFontSize};
-  color: ${props => props.theme.colors.text};
-  font-family: ${props => props.theme.fonts.contentFontBold};
+const Message = styled(HeadingText)`
   width: ${wp('60%')}px;
   margin-bottom: ${props => props.theme.spacings.lg};
   padding-top: ${props => props.theme.spacings.lg};

--- a/src/components/CustomDisciplineItem.tsx
+++ b/src/components/CustomDisciplineItem.tsx
@@ -9,6 +9,7 @@ import { childrenDescription } from '../services/helpers'
 import DeletionSwipeable from './DeletionSwipeable'
 import DisciplineItem from './DisciplineItem'
 import Loading from './Loading'
+import { ContentSecondaryLight } from './text/Content'
 
 const Placeholder = styled.View`
   background-color: ${props => props.theme.colors.backgroundAccent};
@@ -22,18 +23,8 @@ const LoadingSpinner = styled.View`
   padding-top: ${props => props.theme.spacings.xl};
 `
 
-const Description = styled.Text<{ selected: boolean }>`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
+const Description = styled(ContentSecondaryLight)<{ selected: boolean }>`
   color: ${props => (props.selected ? props.theme.colors.backgroundAccent : props.theme.colors.textSecondary)};
-`
-
-const ErrorText = styled.Text`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  color: ${props => props.theme.colors.primary};
 `
 
 interface CustomDisciplineItemProps {
@@ -82,9 +73,9 @@ const CustomDisciplineItem = ({
         </DisciplineItem>
       ) : (
         <Placeholder>
-          <ErrorText>
+          <ContentSecondaryLight>
             {labels.home.errorLoadCustomDiscipline} {apiKey}
-          </ErrorText>
+          </ContentSecondaryLight>
         </Placeholder>
       )}
     </DeletionSwipeable>

--- a/src/components/DisciplineItem.tsx
+++ b/src/components/DisciplineItem.tsx
@@ -4,6 +4,7 @@ import { heightPercentageToDP as hp, widthPercentageToDP as wp } from 'react-nat
 import styled, { useTheme } from 'styled-components/native'
 
 import { ChevronRight } from '../../assets/images'
+import { ContentSecondaryLight } from './text/Content'
 
 const Container = styled(Pressable)<{ pressed: boolean }>`
   min-height: ${hp('12%')}px;
@@ -44,10 +45,7 @@ const DescriptionContainer = styled.View`
   align-items: center;
 `
 
-const Description = styled.Text<{ pressed: boolean }>`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
+const Description = styled(ContentSecondaryLight)<{ pressed: boolean }>`
   color: ${props => (props.pressed ? props.theme.colors.backgroundAccent : props.theme.colors.textSecondary)};
 `
 

--- a/src/components/ExerciseHeader.tsx
+++ b/src/components/ExerciseHeader.tsx
@@ -12,12 +12,7 @@ import { RoutesParams } from '../navigation/NavigationTypes'
 import ConfirmationModal from './ConfirmationModal'
 import { NavigationHeaderLeft } from './NavigationHeaderLeft'
 import { NavigationTitle } from './NavigationTitle'
-
-const HeaderText = styled.Text`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  color: ${props => props.theme.colors.textSecondary};
-`
+import { Content } from './text/Content'
 
 const ProgressBar = styled(RNProgressBar)`
   background-color: ${props => props.theme.colors.disabled};
@@ -44,7 +39,7 @@ const ExerciseHeader = ({ navigation, route, currentWord, numberOfWords }: Exerc
             <NavigationTitle>{labels.general.header.cancelExercise}</NavigationTitle>
           </NavigationHeaderLeft>
         ),
-        headerRight: () => <HeaderText>{progressText}</HeaderText>,
+        headerRight: () => <Content>{progressText}</Content>,
         headerRightContainerStyle: {
           paddingHorizontal: wp('4%'),
           maxWidth: wp('25%')

--- a/src/components/ExerciseHeader.tsx
+++ b/src/components/ExerciseHeader.tsx
@@ -12,7 +12,7 @@ import { RoutesParams } from '../navigation/NavigationTypes'
 import ConfirmationModal from './ConfirmationModal'
 import { NavigationHeaderLeft } from './NavigationHeaderLeft'
 import { NavigationTitle } from './NavigationTitle'
-import { Content } from './text/Content'
+import { ContentSecondary } from './text/Content'
 
 const ProgressBar = styled(RNProgressBar)`
   background-color: ${props => props.theme.colors.disabled};
@@ -39,7 +39,7 @@ const ExerciseHeader = ({ navigation, route, currentWord, numberOfWords }: Exerc
             <NavigationTitle>{labels.general.header.cancelExercise}</NavigationTitle>
           </NavigationHeaderLeft>
         ),
-        headerRight: () => <Content>{progressText}</Content>,
+        headerRight: () => <ContentSecondary>{progressText}</ContentSecondary>,
         headerRightContainerStyle: {
           paddingHorizontal: wp('4%'),
           maxWidth: wp('25%')

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -21,6 +21,7 @@ const TitleContent = styled(ContentSecondary)`
 
 const TitleHeading = styled(HeadingText)`
   padding: ${props => props.theme.spacings.xs};
+  text-align: center;
 `
 
 const TitleSubheading = styled(SubheadingText)`

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -3,6 +3,10 @@ import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import { SvgProps } from 'react-native-svg'
 import styled from 'styled-components/native'
 
+import { ContentSecondary } from './text/Content'
+import { HeadingText } from './text/Heading'
+import { SubheadingText } from './text/Subheading'
+
 const Container = styled.View`
   min-height: ${hp('7%')}px;
   align-items: center;
@@ -11,26 +15,16 @@ const Container = styled.View`
   text-align: center;
 `
 
-const ScreenTitle = styled.Text`
-  font-size: ${props => props.theme.fonts.headingFontSize};
-  color: ${props => props.theme.colors.text};
-  font-family: ${props => props.theme.fonts.contentFontBold};
-  text-align: center;
+const TitleContent = styled(ContentSecondary)`
+  margin-top: ${props => props.theme.spacings.xxs};
+`
+
+const TitleHeading = styled(HeadingText)`
   padding: ${props => props.theme.spacings.xs};
 `
 
-const ScreenSubTitle = styled.Text`
+const TitleSubheading = styled(SubheadingText)`
   margin-top: ${props => props.theme.spacings.xs};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  color: ${prop => prop.theme.colors.text};
-  font-family: ${props => props.theme.fonts.contentFontBold};
-`
-
-const Description = styled.Text`
-  margin-top: ${props => props.theme.spacings.xxs};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  color: ${props => props.theme.colors.textSecondary};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
 `
 
 interface ITitleProps {
@@ -44,9 +38,9 @@ interface ITitleProps {
 const Title = ({ titleIcon, title, subtitle, description, children }: ITitleProps): ReactElement => (
   <Container>
     {titleIcon}
-    <ScreenTitle>{title}</ScreenTitle>
-    {subtitle && <ScreenSubTitle>{subtitle}</ScreenSubTitle>}
-    <Description>{description}</Description>
+    <TitleHeading>{title}</TitleHeading>
+    {subtitle && <TitleSubheading>{subtitle}</TitleSubheading>}
+    <TitleContent>{description}</TitleContent>
     {children}
   </Container>
 )

--- a/src/components/text/Content.tsx
+++ b/src/components/text/Content.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/native'
 export const Content = styled.Text`
   font-size: ${props => props.theme.fonts.defaultFontSize};
   font-family: ${props => props.theme.fonts.contentFontRegular};
+  font-weight: ${props => props.theme.fonts.defaultFontWeight};
 `
 
 export const ContentSecondary = styled(Content)`

--- a/src/components/text/Content.tsx
+++ b/src/components/text/Content.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components/native'
+
+export const Content = styled.Text`
+  font-size: ${props => props.theme.fonts.defaultFontSize};
+  font-family: ${props => props.theme.fonts.contentFontRegular};
+`
+
+export const ContentSecondary = styled(Content)`
+  color: ${props => props.theme.colors.textSecondary};
+`
+export const ContentText = styled(Content)`
+  color: ${props => props.theme.colors.text};
+`
+
+export const ContentBackground = styled(Content)`
+  color: ${props => props.theme.colors.background};
+`
+
+export const ContentError = styled(Content)`
+  color: ${props => props.theme.colors.incorrect};
+`
+
+export const ContentSecondaryLight = styled(ContentSecondary)`
+  font-weight: ${props => props.theme.fonts.lightFontWeight};
+`
+
+export const ContentTextLight = styled(ContentText)`
+  font-weight: ${props => props.theme.fonts.lightFontWeight};
+`
+
+export const ContentBackgroundLight = styled(ContentBackground)`
+  font-weight: ${props => props.theme.fonts.lightFontWeight};
+`

--- a/src/components/text/Heading.tsx
+++ b/src/components/text/Heading.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components/native'
+
+export const Heading = styled.Text`
+  font-size: ${props => props.theme.fonts.headingFontSize};
+  font-family: ${props => props.theme.fonts.contentFontBold};
+  font-size: ${props => props.theme.fonts.headingFontSize};
+  text-align: center;
+`
+
+export const HeadingText = styled(Heading)`
+  color: ${props => props.theme.colors.text};
+`

--- a/src/components/text/Heading.tsx
+++ b/src/components/text/Heading.tsx
@@ -3,10 +3,13 @@ import styled from 'styled-components/native'
 export const Heading = styled.Text`
   font-size: ${props => props.theme.fonts.headingFontSize};
   font-family: ${props => props.theme.fonts.contentFontBold};
-  font-size: ${props => props.theme.fonts.headingFontSize};
-  text-align: center;
+  font-weight: ${props => props.theme.fonts.defaultFontWeight};
 `
 
 export const HeadingText = styled(Heading)`
   color: ${props => props.theme.colors.text};
+`
+
+export const HeadingBackground = styled(Heading)`
+  color: ${props => props.theme.colors.background};
 `

--- a/src/components/text/ItemTitle.tsx
+++ b/src/components/text/ItemTitle.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components/native'
+
+const ItemTitle = styled.Text<{ selected: boolean }>`
+  text-align: left;
+  font-weight: ${props => props.theme.fonts.defaultFontWeight};
+  margin-bottom: 2px;
+  font-family: ${props => props.theme.fonts.contentFontBold};
+  font-size: ${props => props.theme.fonts.largeFontSize};
+  letter-spacing: ${props => props.theme.fonts.listTitleLetterSpacing};
+  color: ${prop => (prop.selected ? prop.theme.colors.background : prop.theme.colors.text)};
+`
+export default ItemTitle

--- a/src/components/text/Subheading.tsx
+++ b/src/components/text/Subheading.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components/native'
+
+export const Subheading = styled.Text`
+  font-size: ${props => props.theme.fonts.defaultFontSize};
+  font-family: ${props => props.theme.fonts.contentFontBold};
+  font-weight: ${props => props.theme.fonts.defaultFontWeight};
+`
+
+export const SubheadingText = styled(Subheading)`
+  color: ${prop => prop.theme.colors.text};
+`
+
+export const SubheadingPrimary = styled(Subheading)`
+  color: ${prop => prop.theme.colors.primary};
+`

--- a/src/routes/DisciplineSelectionScreen.tsx
+++ b/src/routes/DisciplineSelectionScreen.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components/native'
 import DisciplineItem from '../components/DisciplineItem'
 import ServerResponseHandler from '../components/ServerResponseHandler'
 import Title from '../components/Title'
+import { ContentSecondaryLight } from '../components/text/Content'
 import { Discipline } from '../constants/endpoints'
 import { useLoadDisciplines } from '../hooks/useLoadDisciplines'
 import { RoutesParams } from '../navigation/NavigationTypes'
@@ -27,12 +28,9 @@ const StyledList = styled(FlatList)`
   width: 100%;
 ` as ComponentType as new () => FlatList<Discipline>
 
-const Description = styled.Text<{ selected: boolean }>`
+const Description = styled(ContentSecondaryLight)<{ selected: boolean }>`
   text-align: center;
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
   padding-left: ${props => props.theme.spacings.xxs};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
   color: ${prop => (prop.selected ? prop.theme.colors.background : prop.theme.colors.textSecondary)};
 `
 

--- a/src/routes/ExercisesScreens.tsx
+++ b/src/routes/ExercisesScreens.tsx
@@ -8,6 +8,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { ChevronRight } from '../../assets/images'
 import Title from '../components/Title'
 import Trophy from '../components/Trophy'
+import { ContentSecondaryLight } from '../components/text/Content'
+import ItemTitle from '../components/text/ItemTitle'
 import { EXERCISES, Exercise } from '../constants/data'
 import labels from '../constants/labels.json'
 import { RoutesParams } from '../navigation/NavigationTypes'
@@ -19,16 +21,13 @@ const Root = styled.View`
   height: 100%;
 `
 
-const ItemTitle = styled(FlatList)`
+const StyledList = styled(FlatList)`
   width: ${wp('100%')}px;
   padding-right: ${props => props.theme.spacings.md};
   padding-left: ${props => props.theme.spacings.md};
 ` as ComponentType as new () => FlatList<Exercise>
 
-const Description = styled.Text<{ selected: boolean }>`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
+const Description = styled(ContentSecondaryLight)<{ selected: boolean }>`
   color: ${props => (props.selected ? props.theme.colors.backgroundAccent : props.theme.colors.text)};
 `
 
@@ -47,16 +46,6 @@ const Container = styled.Pressable<{ selected: boolean }>`
 
   background-color: ${props => (props.selected ? props.theme.colors.primary : props.theme.colors.backgroundAccent)};
   border-color: ${props => (props.selected ? props.theme.colors.backgroundAccent : props.theme.colors.disabled)};
-`
-const StyledItemTitle = styled.Text<{ selected: boolean }>`
-  text-align: left;
-  font-size: ${props => props.theme.fonts.largeFontSize};
-  font-weight: ${props => props.theme.fonts.defaultFontWeight};
-  letter-spacing: ${props => props.theme.fonts.listTitleLetterSpacing};
-  margin-bottom: 2px;
-  font-family: ${props => props.theme.fonts.contentFontBold};
-
-  color: ${props => (props.selected ? props.theme.colors.background : props.theme.colors.text)};
 `
 
 interface ExercisesScreenProps {
@@ -95,7 +84,7 @@ const ExercisesScreen = ({ route, navigation }: ExercisesScreenProps): JSX.Eleme
     return (
       <Container selected={selected} onPress={() => handleNavigation(item)}>
         <View>
-          <StyledItemTitle selected={selected}>{item.title}</StyledItemTitle>
+          <ItemTitle selected={selected}>{item.title}</ItemTitle>
           <Description selected={selected}>{item.description}</Description>
           <Trophy level={item.level} />
         </View>
@@ -110,7 +99,7 @@ const ExercisesScreen = ({ route, navigation }: ExercisesScreenProps): JSX.Eleme
 
   return (
     <Root>
-      <ItemTitle
+      <StyledList
         data={EXERCISES}
         ListHeaderComponent={Header}
         renderItem={Item}

--- a/src/routes/HomeScreen.tsx
+++ b/src/routes/HomeScreen.tsx
@@ -9,6 +9,8 @@ import CustomDisciplineItem from '../components/CustomDisciplineItem'
 import DisciplineItem from '../components/DisciplineItem'
 import Header from '../components/Header'
 import ServerResponseHandler from '../components/ServerResponseHandler'
+import { ContentSecondary, ContentSecondaryLight } from '../components/text/Content'
+import { SubheadingPrimary } from '../components/text/Subheading'
 import { Discipline } from '../constants/endpoints'
 import labels from '../constants/labels.json'
 import { useLoadDisciplines } from '../hooks/useLoadDisciplines'
@@ -20,12 +22,9 @@ const Root = styled.ScrollView`
   background-color: ${props => props.theme.colors.background};
   height: 100%;
 `
-const StyledText = styled.Text`
+const StyledText = styled(ContentSecondary)`
   margin-top: ${props => props.theme.spacings.xxl};
   text-align: center;
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  color: ${props => props.theme.colors.textSecondary};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
   margin-bottom: ${props => props.theme.spacings.lg};
 `
 
@@ -36,17 +35,12 @@ const AddCustomDisciplineContainer = styled.TouchableOpacity`
   margin: ${props => props.theme.spacings.sm};
 `
 
-const AddCustomDisciplineText = styled.Text`
+const AddCustomDisciplineText = styled(SubheadingPrimary)`
   text-transform: uppercase;
   padding-left: ${props => props.theme.spacings.xs};
-  font-family: ${props => props.theme.fonts.contentFontBold};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
 `
 
-const Description = styled.Text<{ selected: boolean }>`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
+const Description = styled(ContentSecondaryLight)<{ selected: boolean }>`
   color: ${props => (props.selected ? props.theme.colors.backgroundAccent : props.theme.colors.textSecondary)};
 `
 

--- a/src/routes/InitialSummaryScreen.tsx
+++ b/src/routes/InitialSummaryScreen.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components/native'
 
 import { CheckCircleIconWhite, ListIcon, RepeatIcon } from '../../assets/images'
 import Button from '../components/Button'
+import { Heading } from '../components/text/Heading'
 import { BUTTONS_THEME, ExerciseKeys, EXERCISES } from '../constants/data'
 import labels from '../constants/labels.json'
 import { RoutesParams } from '../navigation/NavigationTypes'
@@ -30,12 +31,8 @@ const MessageContainer = styled.View`
   width: 60%;
   margin-top: ${props => props.theme.spacings.sm};
 `
-const Message = styled.Text`
+const Message = styled(Heading)`
   color: ${prop => prop.theme.colors.background};
-  font-size: ${props => props.theme.fonts.headingFontSize};
-  font-family: ${props => props.theme.fonts.contentFontBold};
-  font-weight: ${props => props.theme.fonts.defaultFontWeight};
-  text-align: center;
 `
 
 interface InitialSummaryScreenProps {

--- a/src/routes/InitialSummaryScreen.tsx
+++ b/src/routes/InitialSummaryScreen.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components/native'
 
 import { CheckCircleIconWhite, ListIcon, RepeatIcon } from '../../assets/images'
 import Button from '../components/Button'
-import { Heading } from '../components/text/Heading'
+import { HeadingBackground } from '../components/text/Heading'
 import { BUTTONS_THEME, ExerciseKeys, EXERCISES } from '../constants/data'
 import labels from '../constants/labels.json'
 import { RoutesParams } from '../navigation/NavigationTypes'
@@ -31,8 +31,8 @@ const MessageContainer = styled.View`
   width: 60%;
   margin-top: ${props => props.theme.spacings.sm};
 `
-const Message = styled(Heading)`
-  color: ${prop => prop.theme.colors.background};
+const Message = styled(HeadingBackground)`
+  text-align: center;
 `
 
 interface InitialSummaryScreenProps {

--- a/src/routes/ResultsOverviewScreen.tsx
+++ b/src/routes/ResultsOverviewScreen.tsx
@@ -9,6 +9,9 @@ import { ChevronRight, DoubleCheckIcon, RepeatIcon } from '../../assets/images'
 import Button from '../components/Button'
 import Title from '../components/Title'
 import Trophy from '../components/Trophy'
+import { ContentSecondaryLight } from '../components/text/Content'
+import ItemTitle from '../components/text/ItemTitle'
+import { SubheadingPrimary } from '../components/text/Subheading'
 import { BUTTONS_THEME, ExerciseKeys, EXERCISES, RESULTS, Result, SIMPLE_RESULTS } from '../constants/data'
 import labels from '../constants/labels.json'
 import { useTabletHeaderHeight } from '../hooks/useTabletHeaderHeight'
@@ -28,10 +31,7 @@ const StyledList = styled(FlatList)`
   margin-bottom: ${props => props.theme.spacings.md};
 ` as ComponentType as new () => FlatList<Result>
 
-const Description = styled.Text<{ selected: boolean }>`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
+const Description = styled(ContentSecondaryLight)<{ selected: boolean }>`
   color: ${prop => (prop.selected ? prop.theme.colors.backgroundAccent : prop.theme.colors.text)};
 `
 
@@ -50,15 +50,6 @@ const Contained = styled.Pressable<{ selected: boolean }>`
   background-color: ${prop => (prop.selected ? prop.theme.colors.primary : prop.theme.colors.backgroundAccent)};
   border-color: ${prop => (prop.selected ? prop.theme.colors.backgroundAccent : prop.theme.colors.disabled)};
 `
-const StyledItemTitle = styled.Text<{ selected: boolean }>`
-  text-align: left;
-  font-weight: ${props => props.theme.fonts.defaultFontWeight};
-  margin-bottom: 2px;
-  font-family: ${props => props.theme.fonts.contentFontBold};
-  font-size: ${props => props.theme.fonts.largeFontSize};
-  letter-spacing: ${props => props.theme.fonts.listTitleLetterSpacing};
-  color: ${prop => (prop.selected ? prop.theme.colors.background : prop.theme.colors.text)};
-`
 
 const LeftSide = styled.View`
   display: flex;
@@ -71,12 +62,8 @@ const StyledText = styled.View`
   display: flex;
   flex-direction: column;
 `
-const HeaderText = styled.Text`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.defaultFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontBold};
+const HeaderText = styled(SubheadingPrimary)`
   letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
-  color: ${prop => prop.theme.colors.primary};
   text-transform: uppercase;
   margin-right: ${props => props.theme.spacings.xs};
 `
@@ -182,7 +169,7 @@ const ResultsOverview = ({ navigation, route }: ResultOverviewScreenProps): Reac
         <LeftSide>
           <item.Icon fill={iconColor} width={wp('7%')} height={wp('7%')} />
           <StyledText>
-            <StyledItemTitle selected={selected}>{item.title}</StyledItemTitle>
+            <ItemTitle selected={selected}>{item.title}</ItemTitle>
             <Description
               selected={
                 selected

--- a/src/routes/add-custom-discipline/AddCustomDisciplineScreen.tsx
+++ b/src/routes/add-custom-discipline/AddCustomDisciplineScreen.tsx
@@ -24,6 +24,7 @@ const Container = styled.View`
 
 const CustomDisciplineHeading = styled(HeadingText)`
   padding-top: ${props => props.theme.spacings.xl};
+  text-align: center;
 `
 
 const Description = styled(ContentSecondary)`

--- a/src/routes/add-custom-discipline/AddCustomDisciplineScreen.tsx
+++ b/src/routes/add-custom-discipline/AddCustomDisciplineScreen.tsx
@@ -7,6 +7,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { QRCodeIcon } from '../../../assets/images'
 import Button from '../../components/Button'
 import Loading from '../../components/Loading'
+import { ContentError, ContentSecondary } from '../../components/text/Content'
+import { HeadingText } from '../../components/text/Heading'
 import { BUTTONS_THEME } from '../../constants/data'
 import labels from '../../constants/labels.json'
 import { loadGroupInfo } from '../../hooks/useLoadGroupInfo'
@@ -20,16 +22,11 @@ const Container = styled.View`
   align-items: center;
 `
 
-const Heading = styled.Text`
-  font-family: ${props => props.theme.fonts.contentFontBold};
-  font-size: ${props => props.theme.fonts.headingFontSize};
+const CustomDisciplineHeading = styled(HeadingText)`
   padding-top: ${props => props.theme.spacings.xl};
 `
 
-const Description = styled.Text`
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  color: ${props => props.theme.colors.textSecondary};
+const Description = styled(ContentSecondary)`
   padding: ${props => `${props.theme.spacings.xs} 0`};
 `
 
@@ -59,12 +56,6 @@ const ErrorContainer = styled.View`
   margin-bottom: ${props => props.theme.spacings.sm};
   width: 80%;
   height: 10%;
-`
-
-const ErrorText = styled.Text`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  color: ${prop => prop.theme.colors.incorrect};
 `
 
 const HTTP_STATUS_CODE_FORBIDDEN = 403
@@ -117,7 +108,7 @@ const AddCustomDiscipline = ({ navigation }: AddCustomDisciplineScreenProps): JS
     <Loading isLoading={loading}>
       {customDisciplines && (
         <Container>
-          <Heading>{labels.addCustomDiscipline.heading}</Heading>
+          <CustomDisciplineHeading>{labels.addCustomDiscipline.heading}</CustomDisciplineHeading>
           <Description>{labels.addCustomDiscipline.description}</Description>
           <InputContainer errorMessage={errorMessage}>
             <StyledTextInput
@@ -132,7 +123,7 @@ const AddCustomDiscipline = ({ navigation }: AddCustomDisciplineScreenProps): JS
           </InputContainer>
 
           <ErrorContainer>
-            <ErrorText>{errorMessage}</ErrorText>
+            <ContentError>{errorMessage}</ContentError>
           </ErrorContainer>
           <Button
             label={labels.addCustomDiscipline.submitLabel}

--- a/src/routes/add-custom-discipline/components/NotAuthorisedView.tsx
+++ b/src/routes/add-custom-discipline/components/NotAuthorisedView.tsx
@@ -3,6 +3,7 @@ import { Linking } from 'react-native'
 import styled from 'styled-components/native'
 
 import Button from '../../../components/Button'
+import { ContentSecondary } from '../../../components/text/Content'
 import { BUTTONS_THEME } from '../../../constants/data'
 import labels from '../../../constants/labels.json'
 
@@ -15,10 +16,7 @@ const Container = styled.View`
   margin: ${props => `${props.theme.spacings.xxl} 0 0`};
 `
 
-const Description = styled.Text`
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  color: ${props => props.theme.colors.textSecondary};
+const Description = styled(ContentSecondary)`
   padding: ${props => `0 ${props.theme.spacings.md} ${props.theme.spacings.md}`};
   text-align: center;
 `

--- a/src/routes/choice-exercises/components/SingleChoiceListItem.tsx
+++ b/src/routes/choice-exercises/components/SingleChoiceListItem.tsx
@@ -1,16 +1,10 @@
 import React, { useState } from 'react'
 import styled, { css } from 'styled-components/native'
 
+import { ContentSecondary, ContentSecondaryLight } from '../../../components/text/Content'
 import { Answer, Article } from '../../../constants/data'
 import labels from '../../../constants/labels.json'
 import { getArticleColor } from '../../../services/helpers'
-
-const StyledText = styled.Text`
-  font-family: ${props => props.theme.fonts.contentFontRegular};
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-style: normal;
-`
 
 const Container = styled.TouchableOpacity<StyledListElementProps>`
   height: 23.5%;
@@ -85,7 +79,7 @@ const ArticleBox = styled.View<StyledListElementProps & { article: Article }>`
   }};
 `
 
-const ArticleText = styled(StyledText)<StyledListElementProps>`
+const ArticleText = styled(ContentSecondary)<StyledListElementProps>`
   text-align: center;
   color: ${props => {
     if (props.pressed) {
@@ -101,7 +95,7 @@ const ArticleText = styled(StyledText)<StyledListElementProps>`
   }};
 `
 
-const Word = styled(StyledText)<StyledListElementProps>`
+const Word = styled(ContentSecondaryLight)<StyledListElementProps>`
   color: ${props => {
     if (props.pressed) {
       return props.theme.colors.background

--- a/src/routes/vocabulary-list/components/VocabularyListItem.tsx
+++ b/src/routes/vocabulary-list/components/VocabularyListItem.tsx
@@ -4,6 +4,7 @@ import { widthPercentageToDP as wp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
 import AudioPlayer from '../../../components/AudioPlayer'
+import { ContentSecondaryLight, ContentTextLight } from '../../../components/text/Content'
 import { Document } from '../../../constants/endpoints'
 import { getArticleColor } from '../../../services/helpers'
 
@@ -34,25 +35,17 @@ const StyledImage = styled.Image`
   height: ${wp('15%')}px;
   border-radius: ${props => props.theme.spacings.xxl};
 `
-const StyledTitle = styled.Text<{ articleColor: string }>`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
+const StyledTitle = styled(ContentTextLight)<{ articleColor: string }>`
   border-radius: ${props => props.theme.spacings.xs};
   margin-bottom: ${props => props.theme.spacings.xxs};
-  color: ${props => props.theme.colors.text};
   background-color: ${props => props.articleColor};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
   align-self: flex-start;
   width: ${wp('10%')}px;
   overflow: hidden;
   height: ${wp('5%')}px;
   text-align: center;
 `
-const Description = styled.Text`
-  font-size: ${props => props.theme.fonts.defaultFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  color: ${props => props.theme.colors.textSecondary};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
+const Description = styled(ContentSecondaryLight)`
   margin-left: ${props => props.theme.spacings.xs};
 `
 const Speaker = styled.View`

--- a/src/routes/write-exercise/components/MissingArticlePopover.tsx
+++ b/src/routes/write-exercise/components/MissingArticlePopover.tsx
@@ -5,6 +5,7 @@ import { widthPercentageToDP as wp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
 import { InfoCircleIcon } from '../../../../assets/images'
+import { ContentBackgroundLight } from '../../../components/text/Content'
 import labels from '../../../constants/labels.json'
 import { COLORS } from '../../../constants/theme/colors'
 
@@ -26,11 +27,8 @@ const StyledContainer = styled.View`
   padding: ${props => props.theme.spacings.xs};
   border-radius: 2px;
 `
-const StyledMessage = styled.Text`
-  color: ${prop => prop.theme.colors.background};
+const StyledMessage = styled(ContentBackgroundLight)`
   font-size: ${props => props.theme.fonts.smallFontSize};
-  font-weight: ${props => props.theme.fonts.lightFontWeight};
-  font-family: ${props => props.theme.fonts.contentFontRegular};
   width: ${wp('60%')}px;
   margin-left: ${props => props.theme.spacings.xs};
 `


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

I created text component with according to the following schema:
`<TextType><Color><FontWeight>`
Example:
`ContentSecondaryLight`

If there are any better suggestions, please let me know