### PR TITLE
LUN-272: Incorrect names for additional areas

### DIFF
--- a/release-notes/unreleased/LUN-272-incorrect-names-for-additional-areas.yml
+++ b/release-notes/unreleased/LUN-272-incorrect-names-for-additional-areas.yml
@@ -1,5 +1,5 @@
 issue_key: LUN-272
-show_in_stores: true
+show_in_stores: false
 platforms:
   - android
   - ios

--- a/release-notes/unreleased/LUN-272-incorrect-names-for-additional-areas.yml
+++ b/release-notes/unreleased/LUN-272-incorrect-names-for-additional-areas.yml
@@ -1,0 +1,6 @@
+issue_key: LUN-272
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Fehlerhalfte Titel von individuellen Bereichen behoben

--- a/src/components/CustomDisciplineItem.tsx
+++ b/src/components/CustomDisciplineItem.tsx
@@ -1,5 +1,6 @@
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
+import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
 import labels from '../constants/labels.json'
@@ -7,19 +8,17 @@ import { useLoadGroupInfo } from '../hooks/useLoadGroupInfo'
 import { RoutesParams } from '../navigation/NavigationTypes'
 import DeletionSwipeable from './DeletionSwipeable'
 import DisciplineListItem from './DisciplineListItem'
+import { GenericListContainer } from './ListItem'
 import Loading from './Loading'
 import { ContentSecondaryLight } from './text/Content'
 
-const Placeholder = styled.View`
-  background-color: ${props => props.theme.colors.backgroundAccent};
-  margin: ${props => `0 ${props.theme.spacings.sm} ${props.theme.spacings.xs} ${props.theme.spacings.sm}`};
+const Placeholder = styled(GenericListContainer)`
   border: 1px solid ${prop => prop.theme.colors.disabled};
-  border-radius: 2px;
-  padding: ${props => props.theme.spacings.sm};
+  height: ${hp('12%')}px;
 `
 
 const LoadingSpinner = styled.View`
-  padding-top: ${props => props.theme.spacings.xl};
+  padding: ${props => props.theme.spacings.md};
 `
 
 interface CustomDisciplineItemProps {

--- a/src/components/CustomDisciplineItem.tsx
+++ b/src/components/CustomDisciplineItem.tsx
@@ -8,11 +8,11 @@ import { useLoadGroupInfo } from '../hooks/useLoadGroupInfo'
 import { RoutesParams } from '../navigation/NavigationTypes'
 import DeletionSwipeable from './DeletionSwipeable'
 import DisciplineListItem from './DisciplineListItem'
-import { GenericListContainer } from './ListItem'
+import { GenericListItemContainer } from './ListItem'
 import Loading from './Loading'
 import { ContentSecondaryLight } from './text/Content'
 
-const Placeholder = styled(GenericListContainer)`
+const Placeholder = styled(GenericListItemContainer)`
   border: 1px solid ${prop => prop.theme.colors.disabled};
   height: ${hp('12%')}px;
 `

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -1,25 +1,29 @@
 import React, { ReactElement, useCallback, useState } from 'react'
-import { GestureResponderEvent, Pressable } from 'react-native'
+import { GestureResponderEvent } from 'react-native'
 import { heightPercentageToDP as hp, widthPercentageToDP as wp } from 'react-native-responsive-screen'
 import styled, { useTheme } from 'styled-components/native'
 
 import { ChevronRight } from '../../assets/images'
 import { ContentSecondaryLight } from './text/Content'
 
-const Container = styled(Pressable)<{ pressed: boolean }>`
-  min-height: ${hp('12%')}px;
+export const GenericListContainer = styled.Pressable`
   width: ${wp('90%')}px;
   margin-bottom: ${props => props.theme.spacings.xxs};
   align-self: center;
-  padding: ${props =>
-    `${props.theme.spacings.sm} ${props.theme.spacings.xs} ${props.theme.spacings.sm} ${props.theme.spacings.sm}`};
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  background-color: ${prop => (prop.pressed ? prop.theme.colors.primary : prop.theme.colors.backgroundAccent)};
-  border: 1px solid ${prop => (prop.pressed ? prop.theme.colors.primary : prop.theme.colors.disabled)};
   border-radius: 2px;
 `
+
+const Container = styled(GenericListContainer)<{ pressed: boolean }>`
+  min-height: ${hp('12%')}px;
+  background-color: ${prop => (prop.pressed ? prop.theme.colors.primary : prop.theme.colors.backgroundAccent)};
+  border: 1px solid ${prop => (prop.pressed ? prop.theme.colors.primary : prop.theme.colors.disabled)};
+  padding: ${props =>
+    `${props.theme.spacings.sm} ${props.theme.spacings.xs} ${props.theme.spacings.sm} ${props.theme.spacings.sm}`};
+`
+
 const Title = styled.Text<{ pressed: boolean }>`
   font-size: ${props => props.theme.fonts.largeFontSize};
   letter-spacing: ${props => props.theme.fonts.listTitleLetterSpacing};

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -6,7 +6,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { ChevronRight } from '../../assets/images'
 import { ContentSecondaryLight } from './text/Content'
 
-export const GenericListContainer = styled.Pressable`
+export const GenericListItemContainer = styled.Pressable`
   width: ${wp('90%')}px;
   margin-bottom: ${props => props.theme.spacings.xxs};
   align-self: center;
@@ -16,7 +16,7 @@ export const GenericListContainer = styled.Pressable`
   border-radius: 2px;
 `
 
-const Container = styled(GenericListContainer)<{ pressed: boolean }>`
+const Container = styled(GenericListItemContainer)<{ pressed: boolean }>`
   min-height: ${hp('12%')}px;
   background-color: ${prop => (prop.pressed ? prop.theme.colors.primary : prop.theme.colors.backgroundAccent)};
   border: 1px solid ${prop => (prop.pressed ? prop.theme.colors.primary : prop.theme.colors.disabled)};

--- a/src/components/ServerResponseHandler.tsx
+++ b/src/components/ServerResponseHandler.tsx
@@ -12,8 +12,8 @@ interface ServerResponseHandlerProps {
 
 const ServerResponseHandler = ({ loading, error, refresh, children }: ServerResponseHandlerProps): ReactElement => (
   <Loading isLoading={loading}>
-    <ErrorMessage error={error} refresh={refresh} />
     {children}
+    <ErrorMessage error={error} refresh={refresh} />
   </Loading>
 )
 

--- a/src/hooks/__tests__/useLoadFromEndpoint.spec.ts
+++ b/src/hooks/__tests__/useLoadFromEndpoint.spec.ts
@@ -6,7 +6,7 @@ import { loadAsync } from '../useLoadAsync'
 
 jest.mock('axios', () => ({ get: jest.fn() }))
 
-jest.mock('axios-cache-interceptor', () => ({ setupCache: jest.fn() }))
+jest.mock('axios-cache-interceptor', () => ({ setupCache: jest.fn(), buildKeyGenerator: jest.fn() }))
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/src/routes/DisciplineSelectionScreen.tsx
+++ b/src/routes/DisciplineSelectionScreen.tsx
@@ -19,6 +19,7 @@ const Root = styled.View`
 
 const StyledList = styled(FlatList)`
   width: 100%;
+  flex-grow: 0;
 ` as ComponentType as new () => FlatList<Discipline>
 
 interface DisciplineSelectionScreenProps {

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,11 +1,21 @@
 import axios from 'axios'
-import { setupCache } from 'axios-cache-interceptor'
+import { buildKeyGenerator, setupCache } from 'axios-cache-interceptor'
 
 import { addTrailingSlashToUrl } from './url'
 
 const baseURL = __DEV__ ? 'https://lunes-test.tuerantuer.org/api' : 'https://lunes.tuerantuer.org/api'
 
-setupCache(axios)
+const keyGenerator = buildKeyGenerator(true, ({ headers, baseURL = '', url = '', method = 'get', params, data }) => ({
+  url: baseURL + (baseURL && url ? '/' : '') + url,
+  headers: headers?.Authorization ?? 'not-set',
+  method,
+  params: params as unknown,
+  data
+}))
+
+setupCache(axios, {
+  generateKey: keyGenerator
+})
 
 export const getFromEndpoint = async <T>(url: string, apiKey?: string): Promise<T> => {
   const headers = apiKey ? { Authorization: `Api-Key ${apiKey}` } : undefined


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

I fixed several things here:
1) Wrong names of multiple custom disciplines: axios-cache did handle them the same way as they only differ in the Auth-header.
2) Jumping of custom disciplines, because container while loading has different size/margins
3) Error message above Title in a module, when loading fails which looks bad, see here https://issues.tuerantuer.org/browse/LUN-271


api-key for testing:
rXTIfCwz.eOYXwwn486fR5PlKFW9KagLtIzwwBCrE
qYA.YYyZben

