### PR TITLE
LUN-289: Show empty custom disciplines

### DIFF
--- a/release-notes/unreleased/LUN-289-show-empty-custom-disciplines.yml
+++ b/release-notes/unreleased/LUN-289-show-empty-custom-disciplines.yml
@@ -1,0 +1,6 @@
+issue_key: LUN-289
+show_in_stores: false
+platforms:
+  - android
+  - ios
+de: Leere persönliche Bereiche werden nun angezeigt.

--- a/src/components/DisciplineListItem.tsx
+++ b/src/components/DisciplineListItem.tsx
@@ -11,12 +11,12 @@ interface DisciplineListItemProps {
 }
 
 const DisciplineListItem = ({ item, onPress, hasBadge }: DisciplineListItemProps): ReactElement | null => {
-  const { numberOfChildren, title, icon } = item
+  const { numberOfChildren, title, icon, apiKey } = item
   const badgeLabel = hasBadge ? numberOfChildren.toString() : undefined
   // Description either contains the number of children and the type of children or just the type of children if the number is shown as badge
   const description = hasBadge ? childrenLabel(item) : childrenDescription(item)
 
-  if (numberOfChildren === 0) {
+  if (numberOfChildren === 0 && !apiKey) {
     return null
   }
   return <ListItem title={title} icon={icon} description={description} onPress={onPress} badgeLabel={badgeLabel} />


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.
