### PR TITLE
LUN-282: Error unable to open url mailto

### DIFF
--- a/ios/Lunes/Info.plist
+++ b/ios/Lunes/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+    <string>mailto</string>
+    <string>tel</string>
+    </array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/src/services/url.ts
+++ b/src/services/url.ts
@@ -7,7 +7,7 @@ export const openExternalUrl = (url: string): Promise<void> =>
   Linking.canOpenURL(url)
     .then(supported => {
       if (!supported) {
-        // emulators do not support certain schemes like mailto or tel
+        // iOS Simulators do not support certain schemes like mailto or tel
         console.log('Cannot handle url', url)
         return null
       }

--- a/src/services/url.ts
+++ b/src/services/url.ts
@@ -5,5 +5,12 @@ export const addTrailingSlashToUrl = (url: string): string => (url.endsWith('/')
 
 export const openExternalUrl = (url: string): Promise<void> =>
   Linking.canOpenURL(url)
-    .then(() => Linking.openURL(url))
+    .then(supported => {
+      if (!supported) {
+        // emulators do not support certain schemes like mailto or tel
+        console.log('Cannot handle url', url)
+        return null
+      }
+      return Linking.openURL(url)
+    })
     .catch()

--- a/src/services/url.ts
+++ b/src/services/url.ts
@@ -1,5 +1,7 @@
 import { Linking } from 'react-native'
 
+import { log } from './sentry'
+
 // fix ios issue for Django, that requires trailing slash in request url https://github.com/square/retrofit/issues/1037
 export const addTrailingSlashToUrl = (url: string): string => (url.endsWith('/') ? url : `${url}/`)
 
@@ -8,7 +10,7 @@ export const openExternalUrl = (url: string): Promise<void> =>
     .then(supported => {
       if (!supported) {
         // iOS Simulators do not support certain schemes like mailto or tel
-        console.log('Cannot handle url', url)
+        log(`Cannot handle url: ${url}`)
         return null
       }
       return Linking.openURL(url)


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

Both fixes are only necessary for emulators to avoid errors. On real devices everything works as expected.

`tel` & `mailto` can only be tested on real ios devices. Just added handling for not supported devices like emulators
Impressum-> Click on mailaddress
