### PR TITLE
LUN-318: Exercises screen shows wrong list title

### DIFF
--- a/src/hooks/useLoadAsync.ts
+++ b/src/hooks/useLoadAsync.ts
@@ -35,7 +35,7 @@ export const useLoadAsync = <T, P>(request: (params: P) => Promise<T>, params: P
 
   const load = useCallback(() => {
     loadAsync<T, P>(request, params, setData, setError, setLoading).catch(e => setError(e))
-  // TODO LUN-330 fix object comparison
+    // TODO LUN-330 fix object comparison
   }, [request, JSON.stringify(params)])
 
   useEffect(() => {

--- a/src/hooks/useLoadAsync.ts
+++ b/src/hooks/useLoadAsync.ts
@@ -35,7 +35,8 @@ export const useLoadAsync = <T, P>(request: (params: P) => Promise<T>, params: P
 
   const load = useCallback(() => {
     loadAsync<T, P>(request, params, setData, setError, setLoading).catch(e => setError(e))
-  }, [request, params])
+  // TODO LUN-330 fix object comparison
+  }, [request, JSON.stringify(params)])
 
   useEffect(() => {
     load()

--- a/src/navigation/NavigationTypes.ts
+++ b/src/navigation/NavigationTypes.ts
@@ -16,8 +16,10 @@ interface ExerciseParams {
   closeExerciseAction: CommonNavigationAction
 }
 
-export interface ExercisesParams {
+export interface ExercisesParams extends Omit<ExerciseParams, 'documents' | 'closeExerciseAction'> {
   discipline: Discipline
+  documents: Document[] | null
+  closeExerciseAction?: CommonNavigationAction
 }
 
 type ResultParams = ExerciseParams & {

--- a/src/navigation/NavigationTypes.ts
+++ b/src/navigation/NavigationTypes.ts
@@ -9,16 +9,14 @@ export interface DocumentResult {
   numberOfTries: number
 }
 
-export interface ExerciseParams {
+interface ExerciseParams {
   disciplineTitle: string
   documents: Document[]
   closeExerciseAction: CommonNavigationAction
 }
 
 export interface ExercisesParams {
-  documents: null
   discipline: Discipline
-  disciplineTitle: string
 }
 
 type ResultParams = ExerciseParams & {

--- a/src/navigation/NavigationTypes.ts
+++ b/src/navigation/NavigationTypes.ts
@@ -9,19 +9,17 @@ export interface DocumentResult {
   numberOfTries: number
 }
 
-interface ExerciseParams {
+export interface ExerciseParams {
   disciplineTitle: string
   documents: Document[]
   closeExerciseAction: CommonNavigationAction
 }
 
-export type ExercisesParams =
-  | {
-      documents: null
-      discipline: Discipline
-      disciplineTitle: string
-    }
-  | ExerciseParams
+export interface ExercisesParams {
+  documents: null
+  discipline: Discipline
+  disciplineTitle: string
+}
 
 type ResultParams = ExerciseParams & {
   exercise: ExerciseKey

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -156,7 +156,12 @@ const Navigator = (): JSX.Element | null => {
         />
         <Stack.Screen
           options={({ route: { params }, navigation }) =>
-            defaultOptions(params.disciplineTitle, ArrowLeftCircleIconWhite, navigation, true)
+            defaultOptions(
+              params.discipline.parentTitle ?? labels.general.header.overview,
+              ArrowLeftCircleIconWhite,
+              navigation,
+              true
+            )
           }
           name='Exercises'
           component={ExercisesScreen}

--- a/src/routes/DisciplineSelectionScreen.tsx
+++ b/src/routes/DisciplineSelectionScreen.tsx
@@ -33,9 +33,7 @@ const DisciplineSelectionScreen = ({ route, navigation }: DisciplineSelectionScr
   const handleNavigation = (selectedItem: Discipline): void => {
     if (selectedItem.isLeaf) {
       navigation.navigate('Exercises', {
-        discipline: selectedItem,
-        disciplineTitle: selectedItem.title,
-        documents: null
+        discipline: selectedItem
       })
     } else {
       navigation.push('DisciplineSelection', {

--- a/src/routes/DisciplineSelectionScreen.tsx
+++ b/src/routes/DisciplineSelectionScreen.tsx
@@ -32,7 +32,7 @@ const DisciplineSelectionScreen = ({ route, navigation }: DisciplineSelectionScr
 
   const handleNavigation = (selectedItem: Discipline): void => {
     if (selectedItem.isLeaf) {
-      navigation.navigate('Exercises', { discipline: selectedItem, disciplineTitle: discipline.title, documents: null })
+      navigation.navigate('Exercises', { discipline: selectedItem, disciplineTitle: selectedItem.title, documents: null })
     } else {
       navigation.push('DisciplineSelection', {
         discipline: selectedItem

--- a/src/routes/DisciplineSelectionScreen.tsx
+++ b/src/routes/DisciplineSelectionScreen.tsx
@@ -32,7 +32,11 @@ const DisciplineSelectionScreen = ({ route, navigation }: DisciplineSelectionScr
 
   const handleNavigation = (selectedItem: Discipline): void => {
     if (selectedItem.isLeaf) {
-      navigation.navigate('Exercises', { discipline: selectedItem, disciplineTitle: selectedItem.title, documents: null })
+      navigation.navigate('Exercises', {
+        discipline: selectedItem,
+        disciplineTitle: selectedItem.title,
+        documents: null
+      })
     } else {
       navigation.push('DisciplineSelection', {
         discipline: selectedItem

--- a/src/routes/ExercisesScreen.tsx
+++ b/src/routes/ExercisesScreen.tsx
@@ -11,7 +11,7 @@ import Trophy from '../components/Trophy'
 import { EXERCISES, Exercise } from '../constants/data'
 import useLoadAsync from '../hooks/useLoadAsync'
 import { loadDocuments } from '../hooks/useLoadDocuments'
-import { ExercisesParams, RoutesParams } from '../navigation/NavigationTypes'
+import { ExerciseParams, ExercisesParams, RoutesParams } from '../navigation/NavigationTypes'
 import { wordsDescription } from '../services/helpers'
 
 const Root = styled.View`
@@ -29,7 +29,7 @@ const ExercisesScreen = ({ route, navigation }: ExercisesScreenProps): JSX.Eleme
   const { params } = route
   const { disciplineTitle } = params
 
-  const load = useCallback(async (params: ExercisesParams) => {
+  const load = useCallback(async (params: ExercisesParams | ExerciseParams) => {
     if (params.documents) {
       return params.documents
     }

--- a/src/routes/ExercisesScreen.tsx
+++ b/src/routes/ExercisesScreen.tsx
@@ -1,6 +1,6 @@
 import { CommonActions, RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback } from 'react'
+import React from 'react'
 import { FlatList } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -9,9 +9,8 @@ import ServerResponseHandler from '../components/ServerResponseHandler'
 import Title from '../components/Title'
 import Trophy from '../components/Trophy'
 import { EXERCISES, Exercise } from '../constants/data'
-import useLoadAsync from '../hooks/useLoadAsync'
-import { loadDocuments } from '../hooks/useLoadDocuments'
-import { ExerciseParams, ExercisesParams, RoutesParams } from '../navigation/NavigationTypes'
+import useLoadDocuments from '../hooks/useLoadDocuments'
+import { RoutesParams } from '../navigation/NavigationTypes'
 import { wordsDescription } from '../services/helpers'
 
 const Root = styled.View`
@@ -26,16 +25,10 @@ interface ExercisesScreenProps {
 }
 
 const ExercisesScreen = ({ route, navigation }: ExercisesScreenProps): JSX.Element => {
-  const { params } = route
-  const { disciplineTitle } = params
+  const { discipline } = route.params
+  const { title: disciplineTitle } = discipline
 
-  const load = useCallback(async (params: ExercisesParams | ExerciseParams) => {
-    if (params.documents) {
-      return params.documents
-    }
-    return loadDocuments(params.discipline)
-  }, [])
-  const { data: documents, error, loading, refresh } = useLoadAsync(load, params)
+  const { data: documents, error, loading, refresh } = useLoadDocuments(discipline)
 
   const Header = documents && <Title title={disciplineTitle} description={wordsDescription(documents.length)} />
 

--- a/src/routes/ExercisesScreen.tsx
+++ b/src/routes/ExercisesScreen.tsx
@@ -33,7 +33,12 @@ const ExercisesScreen = ({ route, navigation }: ExercisesScreenProps): JSX.Eleme
 
   const handleNavigation = (item: Exercise): void => {
     if (documents) {
-      const closeExerciseAction = CommonActions.navigate('Exercises', { documents, disciplineTitle, disciplineId })
+      const closeExerciseAction = CommonActions.navigate('Exercises', {
+        documents,
+        disciplineTitle,
+        disciplineId,
+        discipline
+      })
       navigation.navigate(EXERCISES[item.key].nextScreen, {
         documents,
         disciplineId,

--- a/src/routes/ExercisesScreen.tsx
+++ b/src/routes/ExercisesScreen.tsx
@@ -27,7 +27,15 @@ interface ExercisesScreenProps {
 const ExercisesScreen = ({ route, navigation }: ExercisesScreenProps): JSX.Element => {
   const { discipline, disciplineTitle, disciplineId } = route.params
 
-  const { data: documents, error, loading, refresh } = useLoadDocuments({ disciplineId: discipline.id, apiKey: discipline.apiKey })
+  const {
+    data: documents,
+    error,
+    loading,
+    refresh
+  } = useLoadDocuments({
+    disciplineId: discipline.id,
+    apiKey: discipline.apiKey
+  })
 
   const Header = documents && <Title title={disciplineTitle} description={wordsDescription(documents.length)} />
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

Choose a discipline and check if the exercise screen uses correct header for navigation and list
