### PR TITLE
LUN-138: Resusable-SingleChoiceListItem

### DIFF
--- a/src/components/SingleChoiceListItem.tsx
+++ b/src/components/SingleChoiceListItem.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from 'react'
 import styled, { css } from 'styled-components/native'
 
-import { ContentSecondary, ContentSecondaryLight } from '../../../components/text/Content'
-import { Answer, Article } from '../../../constants/data'
-import labels from '../../../constants/labels.json'
-import { getArticleColor } from '../../../services/helpers'
+import { Answer, Article } from '../constants/data'
+import labels from '../constants/labels.json'
+import { getArticleColor } from '../services/helpers'
+import { ContentSecondary, ContentSecondaryLight } from './text/Content'
 
 const Container = styled.TouchableOpacity<StyledListElementProps>`
-  height: 23.5%;
   margin-bottom: ${props => props.theme.spacings.xxs};
   border-radius: 2px;
+  flex: 1;
   border-width: ${props => {
     if (props.pressed || props.selected || (props.correct && props.delayPassed)) {
       return '0px'
@@ -116,11 +116,11 @@ const Overlay = styled.View`
 
 export interface SingleChoiceListItemProps {
   answer: Answer
-  onClick: (answer: Answer) => void
-  correct: boolean
-  selected: boolean
-  anyAnswerSelected: boolean
-  delayPassed: boolean
+  correct?: boolean
+  selected?: boolean
+  anyAnswerSelected?: boolean
+  delayPassed?: boolean
+  onClick?: (answer: Answer) => void
   disabled?: boolean
 }
 
@@ -134,10 +134,10 @@ interface StyledListElementProps {
 const SingleChoiceListItem = ({
   answer,
   onClick,
-  correct,
-  selected,
-  anyAnswerSelected,
-  delayPassed,
+  correct = false,
+  selected = false,
+  anyAnswerSelected = false,
+  delayPassed = false,
   disabled = false
 }: SingleChoiceListItemProps): JSX.Element => {
   const [pressed, setPressed] = useState<boolean>(false)
@@ -152,8 +152,10 @@ const SingleChoiceListItem = ({
   }
 
   const onPressOut = (): void => {
-    setPressed(false)
-    onClick(answer)
+    if (onClick) {
+      setPressed(false)
+      onClick(answer)
+    }
   }
 
   return (
@@ -161,7 +163,7 @@ const SingleChoiceListItem = ({
       activeOpacity={1}
       correct={showCorrect}
       selected={selected}
-      onPressIn={onPressIn}
+      onPressIn={onClick && onPressIn}
       onPressOut={onPressOut}
       pressed={pressed}
       delayPassed={delayPassed}

--- a/src/components/WordItem.tsx
+++ b/src/components/WordItem.tsx
@@ -131,7 +131,7 @@ interface StyledListElementProps {
   delayPassed: boolean
 }
 
-const SingleChoiceListItem = ({
+const WordItem = ({
   answer,
   onClick,
   correct = false,
@@ -187,4 +187,4 @@ const SingleChoiceListItem = ({
   )
 }
 
-export default SingleChoiceListItem
+export default WordItem

--- a/src/routes/choice-exercises/components/SingleChoice.tsx
+++ b/src/routes/choice-exercises/components/SingleChoice.tsx
@@ -2,15 +2,14 @@ import React, { ReactElement } from 'react'
 import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
+import SingleChoiceListItem from '../../../components/SingleChoiceListItem'
 import { Answer } from '../../../constants/data'
-import SingleChoiceListItem from './SingleChoiceListItem'
 
 export const StyledContainer = styled.View`
-  padding-top: ${props => props.theme.spacings.md};
-  height: ${hp('35%')}px;
-  margin-left: ${props => props.theme.spacings.md};
-  margin-right: ${props => props.theme.spacings.md};
-  margin-bottom: ${props => props.theme.spacings.sm};
+  margin-top: ${props => props.theme.spacings.md};
+  height: ${hp('33%')}px;
+  width: 85%;
+  align-self: center;
 `
 
 export interface SingleChoiceProps {

--- a/src/routes/choice-exercises/components/SingleChoice.tsx
+++ b/src/routes/choice-exercises/components/SingleChoice.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react'
 import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
-import SingleChoiceListItem from '../../../components/SingleChoiceListItem'
+import WordItem from '../../../components/WordItem'
 import { Answer } from '../../../constants/data'
 
 export const StyledContainer = styled.View`
@@ -33,7 +33,7 @@ export const SingleChoice = ({
   return (
     <StyledContainer>
       {answers.map(answer => (
-        <SingleChoiceListItem
+        <WordItem
           key={`${answer.article.id}-${answer.word}`}
           answer={answer}
           onClick={onClick}

--- a/src/routes/choice-exercises/components/SingleChoiceExercise.tsx
+++ b/src/routes/choice-exercises/components/SingleChoiceExercise.tsx
@@ -24,7 +24,9 @@ const ExerciseContainer = styled.View`
 
 const ButtonContainer = styled.View`
   align-items: center;
-  margin: ${props => `${props.theme.spacings.sm} 0`};
+  justify-content: center;
+  margin-bottom: ${props => props.theme.spacings.sm};
+  flex: 1;
 `
 
 interface SingleChoiceExerciseProps {

--- a/src/routes/vocabulary-list/components/VocabularyListModal.tsx
+++ b/src/routes/vocabulary-list/components/VocabularyListModal.tsx
@@ -7,7 +7,7 @@ import { CloseCircleIconWhite, ArrowRightIcon } from '../../../../assets/images'
 import AudioPlayer from '../../../components/AudioPlayer'
 import Button from '../../../components/Button'
 import ImageCarousel from '../../../components/ImageCarousel'
-import SingleChoiceListItem from '../../../components/SingleChoiceListItem'
+import WordItem from '../../../components/WordItem'
 import { BUTTONS_THEME } from '../../../constants/data'
 import { Document } from '../../../constants/endpoints'
 import labels from '../../../constants/labels.json'
@@ -70,7 +70,7 @@ const VocabularyListModal = ({
           <ImageCarousel images={documents[selectedDocumentIndex].document_image} />
           <AudioPlayer document={documents[selectedDocumentIndex]} disabled={false} />
           <ItemContainer>
-            <SingleChoiceListItem
+            <WordItem
               answer={{
                 word: documents[selectedDocumentIndex].word,
                 article: documents[selectedDocumentIndex].article

--- a/src/routes/vocabulary-list/components/VocabularyListModal.tsx
+++ b/src/routes/vocabulary-list/components/VocabularyListModal.tsx
@@ -7,10 +7,10 @@ import { CloseCircleIconWhite, ArrowRightIcon } from '../../../../assets/images'
 import AudioPlayer from '../../../components/AudioPlayer'
 import Button from '../../../components/Button'
 import ImageCarousel from '../../../components/ImageCarousel'
+import SingleChoiceListItem from '../../../components/SingleChoiceListItem'
 import { BUTTONS_THEME } from '../../../constants/data'
 import { Document } from '../../../constants/endpoints'
 import labels from '../../../constants/labels.json'
-import SingleChoiceListItem from '../../choice-exercises/components/SingleChoiceListItem'
 
 const ModalContainer = styled.View`
   background-color: ${props => props.theme.colors.background};
@@ -28,14 +28,15 @@ const ModalHeader = styled.View`
 `
 
 const ItemContainer = styled.View`
-  padding: ${props => props.theme.spacings.md};
-  height: 45%;
+  margin: ${props => props.theme.spacings.xl} 0;
+  height: 10%;
+  width: 85%;
+  align-self: center;
 `
 
 const ButtonContainer = styled.View`
   display: flex;
-  align-items: center;
-  margin-top: -40%;
+  align-self: center;
 `
 
 interface VocabularyListModalProps {
@@ -74,12 +75,6 @@ const VocabularyListModal = ({
                 word: documents[selectedDocumentIndex].word,
                 article: documents[selectedDocumentIndex].article
               }}
-              onClick={() => undefined}
-              correct={false}
-              selected={false}
-              anyAnswerSelected={false}
-              delayPassed={false}
-              disabled
             />
           </ItemContainer>
           <ButtonContainer>


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

I decided to keep this refactoring quite small because we have to keep the color logic in the component because its depending on state. I could have made a `SingleChoiceItemWrapper` but it's not worth in my opinion. To use the `ListItem` would mean to but a lot of additional logic inside which would make the component itself too complicated. Feel free for discussion if there are better proposals for refactoring