### PR TITLE
LUN-342: Save progress of vocabulary list

### DIFF
--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -52,9 +52,6 @@ export const EXERCISES: Exercise[] = [
   }
 ]
 
-export const exercisesWithoutProgress = 1
-export const exercisesWithProgress = EXERCISES.length - exercisesWithoutProgress
-
 export interface Progress {
   [disciplineId: string]: { [exerciseKey: string]: number | undefined } | undefined
 }

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -49,7 +49,7 @@ const HomeStackNavigator = (): JSX.Element | null => {
           options={({ navigation }) => options(cancelExercise, navigation, true)}
         />
         <Stack.Screen name='ExerciseFinished' component={ExerciseFinishedScreen} options={{ headerShown: false }} />
-        <Stack.Screen name='Result' component={ResultScreen} options={{ headerShown: false }} />
+        <Stack.Screen name='Result' component={ResultScreen} options={({ navigation }) => options('', navigation)} />
         <Stack.Screen
           name='ResultDetail'
           component={ResultDetailScreen}

--- a/src/routes/vocabulary-list/VocabularyListScreen.tsx
+++ b/src/routes/vocabulary-list/VocabularyListScreen.tsx
@@ -1,13 +1,16 @@
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { ComponentType, useState } from 'react'
+import React, { ComponentType, useEffect, useState } from 'react'
 import { FlatList } from 'react-native'
 import styled from 'styled-components/native'
 
 import Title from '../../components/Title'
+import { ExerciseKeys } from '../../constants/data'
 import { Document } from '../../constants/endpoints'
 import labels from '../../constants/labels.json'
 import { RoutesParams } from '../../navigation/NavigationTypes'
+import AsyncStorage from '../../services/AsyncStorage'
+import { reportError } from '../../services/sentry'
 import VocabularyListItem from './components/VocabularyListItem'
 import VocabularyListModal from './components/VocabularyListModal'
 
@@ -28,9 +31,13 @@ interface VocabularyListScreenProps {
 }
 
 const VocabularyListScreen = ({ route }: VocabularyListScreenProps): JSX.Element => {
-  const { documents } = route.params
+  const { documents, disciplineId } = route.params
   const [isModalVisible, setIsModalVisible] = useState(false)
   const [selectedDocumentIndex, setSelectedDocumentIndex] = useState<number>(0)
+
+  useEffect(() => {
+    AsyncStorage.setExerciseProgress(disciplineId, ExerciseKeys.vocabularyList, 1).catch(reportError)
+  }, [])
 
   const renderItem = ({ item, index }: { item: Document; index: number }): JSX.Element => (
     <VocabularyListItem

--- a/src/routes/vocabulary-list/__tests__/VocabularyListScreen.spec.tsx
+++ b/src/routes/vocabulary-list/__tests__/VocabularyListScreen.spec.tsx
@@ -4,6 +4,7 @@ import React, { ComponentProps } from 'react'
 
 import labels from '../../../constants/labels.json'
 import { RoutesParams } from '../../../navigation/NavigationTypes'
+import AsyncStorage from '../../../services/AsyncStorage'
 import DocumentBuilder from '../../../testing/DocumentBuilder'
 import createNavigationMock from '../../../testing/createNavigationPropMock'
 import { mockUseLoadAsyncWithData } from '../../../testing/mockUseLoadFromEndpoint'
@@ -22,6 +23,10 @@ jest.mock('react-native/Libraries/Modal/Modal', () => {
   // @ts-expect-error test
   return props => <Modal {...props} />
 })
+
+jest.mock('../../../services/AsyncStorage', () => ({
+  setExerciseProgress: jest.fn(() => Promise.resolve())
+}))
 
 // the modal always lies on top of the route meaning you'll also find the texts below
 // therefore prefix the word with modal_
@@ -52,6 +57,11 @@ describe('VocabularyListScreen', () => {
   }
 
   const navigation = createNavigationMock<'VocabularyList'>()
+
+  it('should save progress', () => {
+    render(<VocabularyListScreen route={route} navigation={navigation} />)
+    expect(AsyncStorage.setExerciseProgress).toHaveBeenCalledWith(1, 0, 1)
+  })
 
   it('should display vocabulary list', () => {
     mockUseLoadAsyncWithData(documents)

--- a/src/services/__tests__/helpers.spec.tsx
+++ b/src/services/__tests__/helpers.spec.tsx
@@ -36,12 +36,12 @@ describe('helpers', () => {
       mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({}))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
-      expect(exerciseKey).toBe(1)
+      expect(exerciseKey).toBe(0)
     })
 
-    it('should open second exercise of first discipline, if first exercise was finished yet', async () => {
+    it('should open third exercise of first discipline, if two exercise were finished yet', async () => {
       mocked(loadDisciplines).mockReturnValueOnce(Promise.resolve(mockDisciplines(true)))
-      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '1': 1 } }))
+      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '0': 1, '1': 1 } }))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
       expect(exerciseKey).toBe(2)
@@ -49,15 +49,15 @@ describe('helpers', () => {
 
     it('should open first exercise, if only second exercise was finished yet', async () => {
       mocked(loadDisciplines).mockReturnValueOnce(Promise.resolve(mockDisciplines(true)))
-      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '2': 1 } }))
+      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '1': 1 } }))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
-      expect(exerciseKey).toBe(1)
+      expect(exerciseKey).toBe(0)
     })
 
-    it('should open third exercise of first discipline, if two exercises were finished yet', async () => {
+    it('should open third exercise of first discipline, if three exercises were finished yet', async () => {
       mocked(loadDisciplines).mockReturnValueOnce(Promise.resolve(mockDisciplines(true)))
-      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '1': 1, '2': 1 } }))
+      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '0': 1, '1': 1, '2': 1 } }))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
       expect(exerciseKey).toBe(3)
@@ -65,11 +65,11 @@ describe('helpers', () => {
 
     it('should open first exercise of second discipline, if first discipline was finished yet', async () => {
       mocked(loadDisciplines).mockReturnValueOnce(Promise.resolve(mockDisciplines(true)))
-      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '1': 1, '2': 1, '3': 1 } }))
+      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '0': 1, '1': 1, '2': 1, '3': 1 } }))
 
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[1].id)
-      expect(exerciseKey).toBe(1)
+      expect(exerciseKey).toBe(0)
     })
 
     it('should open first exercise of first discipline, if second discipline was partly finished yet', async () => {
@@ -77,7 +77,7 @@ describe('helpers', () => {
       mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '2': { '1': 1, '2': 1 } }))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
-      expect(exerciseKey).toBe(1)
+      expect(exerciseKey).toBe(0)
     })
 
     it('should open first exercise of first discipline, if exercise progress is undefined', async () => {
@@ -85,7 +85,7 @@ describe('helpers', () => {
       mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '1': undefined } }))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
-      expect(exerciseKey).toBe(1)
+      expect(exerciseKey).toBe(0)
     })
 
     it('should open first exercise of first discipline, if discipline progress is undefined', async () => {
@@ -93,7 +93,7 @@ describe('helpers', () => {
       mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': undefined }))
       const { disciplineId, exerciseKey } = await getNextExerciseWithCheck()
       expect(disciplineId).toBe(mockDisciplines()[0].id)
-      expect(exerciseKey).toBe(1)
+      expect(exerciseKey).toBe(0)
     })
   })
 
@@ -117,7 +117,7 @@ describe('helpers', () => {
     })
 
     it('should show 0.5 if one of two disciplines are finished', async () => {
-      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '1': 1, '2': 1, '3': 1 } }))
+      mocked(getExerciseProgress).mockReturnValueOnce(Promise.resolve({ '1': { '0': 1, '1': 1, '2': 1, '3': 1 } }))
       const progress = await getProgress(profession)
       expect(progress).toBe(0.5)
     })

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -1,11 +1,4 @@
-import {
-  Article,
-  EXERCISES,
-  exercisesWithoutProgress,
-  exercisesWithProgress,
-  NextExercise,
-  Progress
-} from '../constants/data'
+import { Article, EXERCISES, NextExercise, Progress } from '../constants/data'
 import { AlternativeWord, Discipline, Document } from '../constants/endpoints'
 import labels from '../constants/labels.json'
 import { COLORS } from '../constants/theme/colors'
@@ -88,21 +81,19 @@ export const getNextExercise = async (profession: Discipline | null): Promise<Ne
   }
   const progress = await AsyncStorage.getExerciseProgress()
   const firstUnfinishedDiscipline = disciplines.find(
-    discipline => doneExercisesOfLeafDiscipline(discipline.id, progress) < exercisesWithProgress
+    discipline => doneExercisesOfLeafDiscipline(discipline.id, progress) < EXERCISES.length
   )
   if (!firstUnfinishedDiscipline) {
-    return { disciplineId: disciplines[0].id, exerciseKey: exercisesWithoutProgress } // TODO LUN-319 show success that every exercise is done
+    return { disciplineId: disciplines[0].id, exerciseKey: 0 } // TODO LUN-319 show success that every exercise is done
   }
   const disciplineProgress = progress[firstUnfinishedDiscipline.id]
   if (!disciplineProgress) {
-    return { disciplineId: firstUnfinishedDiscipline.id, exerciseKey: exercisesWithoutProgress }
+    return { disciplineId: firstUnfinishedDiscipline.id, exerciseKey: 0 }
   }
-  const nextExerciseKey = EXERCISES.slice(exercisesWithoutProgress).find(
-    exercise => disciplineProgress[exercise.key] === undefined
-  )
+  const nextExerciseKey = EXERCISES.find(exercise => disciplineProgress[exercise.key] === undefined)
   return {
     disciplineId: firstUnfinishedDiscipline.id,
-    exerciseKey: nextExerciseKey?.key ?? exercisesWithoutProgress
+    exerciseKey: nextExerciseKey?.key ?? 0
   }
 }
 
@@ -115,6 +106,6 @@ export const getProgress = async (profession: Discipline | null): Promise<number
     (acc, leaf) => acc + doneExercisesOfLeafDiscipline(leaf, progress),
     0
   )
-  const totalExercises = profession.leafDisciplines.length * exercisesWithProgress
+  const totalExercises = profession.leafDisciplines.length * EXERCISES.length
   return doneExercises / totalExercises
 }


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.
