### PR TITLE
LUN-393: Fix failing commands

### DIFF
--- a/tools/git-version.ts
+++ b/tools/git-version.ts
@@ -4,15 +4,6 @@ import { program } from 'commander'
 import { VERSION_FILE, PLATFORMS, tagId, MAIN_BRANCH } from './constants'
 import authenticate from './github-authentication'
 
-program
-  .requiredOption(
-    '--deliverino-private-key <deliverino-private-key>',
-    'private key of the deliverino github app in pem format with base64 encoding'
-  )
-  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
-  .requiredOption('--repo <repo>', 'the current repository, should be lunes-app')
-  .requiredOption('--branch <branch>', 'the current branch')
-
 interface TagOptions {
   versionName: string
   versionCode: number
@@ -106,6 +97,13 @@ const commitAndTag = async (
 program
   .command('bump-to <new-version-name> <new-version-code>')
   .description('commits the supplied version name and code to github and tags the commit')
+  .requiredOption(
+    '--deliverino-private-key <deliverino-private-key>',
+    'private key of the deliverino github app in pem format with base64 encoding'
+  )
+  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
+  .requiredOption('--repo <repo>', 'the current repository, should be lunes-app')
+  .requiredOption('--branch <branch>', 'the current branch')
   .action(async (newVersionName: string, newVersionCode: string, options: Options) => {
     try {
       await commitAndTag(newVersionName, newVersionCode, options)

--- a/tools/github-release.ts
+++ b/tools/github-release.ts
@@ -3,18 +3,6 @@ import { program } from 'commander'
 import { tagId } from './constants'
 import authenticate from './github-authentication'
 
-program
-  .requiredOption(
-    '--deliverino-private-key <deliverino-private-key>',
-    'private key of the deliverino github app in pem format with base64 encoding'
-  )
-  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
-  .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
-  .requiredOption('--release-notes <release-notes>', 'the release notes (for the selected platform) as JSON string')
-  .option('--download-links <download-links>', 'the download links of the artifacts (for the selected platform)')
-  .option('--beta-release', 'whether the release is a beta release which is not delivered to production')
-  .option('--dry-run', 'dry run without actually creating a release on github')
-
 interface Options {
   deliverinoPrivateKey: string
   owner: string
@@ -63,6 +51,16 @@ const githubRelease = async (
 program
   .command('create <platform> <new-version-name> <new-version-code>')
   .description('creates a new release for the specified platform')
+  .requiredOption(
+    '--deliverino-private-key <deliverino-private-key>',
+    'private key of the deliverino github app in pem format with base64 encoding'
+  )
+  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
+  .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
+  .requiredOption('--release-notes <release-notes>', 'the release notes (for the selected platform) as JSON string')
+  .option('--download-links <download-links>', 'the download links of the artifacts (for the selected platform)')
+  .option('--beta-release', 'whether the release is a beta release which is not delivered to production')
+  .option('--dry-run', 'dry run without actually creating a release on github')
   .action(async (platform: string, newVersionName: string, newVersionCode: string, options: Options) => {
     try {
       await githubRelease(platform, newVersionName, newVersionCode, options)

--- a/tools/jira-release.ts
+++ b/tools/jira-release.ts
@@ -13,13 +13,6 @@ interface JiraIssue {
   id: string
 }
 
-program
-  .option('-d, --debug', 'enable extreme logging')
-  .requiredOption('--project-name <project-name>', 'the name of the jira project, e.g. integreat-app')
-  .requiredOption('--access-token <access-token>', 'version name of the new release')
-  .requiredOption('--private-key <privateKey>')
-  .requiredOption('--consumer-key <consumer-key>')
-
 interface Opts {
   accessToken: string
   privateKeyBase64: string
@@ -119,6 +112,10 @@ program
   .description(
     'create a new release with the name <new-version-name> on jira and assign all issues resolved since the last release'
   )
+  .requiredOption('--project-name <project-name>', 'the name of the jira project, e.g. integreat-app')
+  .requiredOption('--access-token <access-token>', 'version name of the new release')
+  .requiredOption('--private-key <privateKey>')
+  .requiredOption('--consumer-key <consumer-key>')
   .action(async (newVersionName: string, options: Opts) => {
     try {
       await createRelease({

--- a/tools/move-release-notes.ts
+++ b/tools/move-release-notes.ts
@@ -3,16 +3,6 @@ import { program } from 'commander'
 import { GITKEEP_FILE, UNRELEASED_DIR, RELEASE_NOTES_DIR } from './constants'
 import authenticate from './github-authentication'
 
-program
-  .option('-d, --debug', 'enable extreme logging')
-  .requiredOption(
-    '--deliverino-private-key <deliverino-private-key>',
-    'private key of the deliverino github app in pem format with base64 encoding'
-  )
-  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
-  .requiredOption('--repo <repo>', 'the current repository, usually "lunes-app"')
-  .requiredOption('--branch <branch>', 'the current branch')
-
 interface Opts {
   deliverinoPrivateKey: string
   owner: string
@@ -114,6 +104,13 @@ const moveReleaseNotes = async ({ newVersionName, deliverinoPrivateKey, owner, r
 program
   .command('move-to <new-version-name>')
   .description("move the release notes in 'unreleased' to a new subdirectory <new-version-name>")
+  .requiredOption(
+    '--deliverino-private-key <deliverino-private-key>',
+    'private key of the deliverino github app in pem format with base64 encoding'
+  )
+  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
+  .requiredOption('--repo <repo>', 'the current repository, usually "lunes-app"')
+  .requiredOption('--branch <branch>', 'the current branch')
   .action(async (newVersionName: string, options: Opts) => {
     try {
       await moveReleaseNotes({


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

Seems like it always have to first be command, then options and only then the action. Otherwise the options are just lost. Only tested commands where this was the case last time :/