### PR TITLE
LUN-xx: Adjust default notes

### DIFF
--- a/tools/constants.ts
+++ b/tools/constants.ts
@@ -4,7 +4,7 @@ const GITKEEP_FILE = '.gitkeep'
 const VERSION_FILE = 'version.json'
 
 const DEFAULT_NOTES =
-  'Wir haben hinter den Kulissen hart gearbeitet, um sicherzustellen, dass alles so funktioniert, wie es soll. Wenn Sie bemerken, dass etwas nicht funktioniert, lassen Sie es uns wissen!\n'
+  'Wir haben die App weiter für Sie verbessert und einige Fehler entfernt. Wenn Sie bemerken, dass etwas nicht funktioniert, lassen Sie es uns wissen!\n'
 
 const PLATFORM_ANDROID = 'android'
 const PLATFORM_IOS = 'ios'


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.


As our Lunes update in Apple store was rejected, because the default notes were not specific enough, I changed them (to the Integreat default)
