### PR TITLE
LUN-395: User created vocabulary list screen

### DIFF
--- a/assets/images/add-icon-white.svg
+++ b/assets/images/add-icon-white.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z" fill="#F9FAFB" fill-rule="evenodd"/>
+</svg>

--- a/assets/images/index.ts
+++ b/assets/images/index.ts
@@ -1,4 +1,5 @@
 import AddCircleIcon from './add-circle-icon.svg'
+import AddIconWhite from './add-icon-white.svg'
 import ArrowLeftCircleIconBlue from './arrow-left-circle-icon-blue.svg'
 import ArrowLeftCircleIconWhite from './arrow-left-circle-icon-white.svg'
 import ArrowRightCircleIconWhite from './arrow-right-circle-icon-white.svg'
@@ -64,6 +65,7 @@ import VolumeUpCircleIcon from './volume-up-circle-icon.svg'
 
 export {
   AddCircleIcon,
+  AddIconWhite,
   ArrowLeftCircleIconBlue,
   ArrowLeftCircleIconWhite,
   ArrowRightIcon,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentType, ReactElement, useState } from 'react'
+import { StyleProp, ViewStyle } from 'react-native'
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import { SvgProps } from 'react-native-svg'
 import styled, { css, useTheme } from 'styled-components/native'
@@ -50,11 +51,12 @@ interface ButtonProps {
   disabled?: boolean
   iconLeft?: ComponentType<SvgProps>
   iconRight?: ComponentType<SvgProps>
+  style?: StyleProp<ViewStyle>
 }
 
 const Button = (props: ButtonProps): ReactElement => {
   const [isPressed, setIsPressed] = useState<boolean>(false)
-  const { label, onPress, disabled = false, buttonTheme = BUTTONS_THEME.outlined } = props
+  const { label, onPress, disabled = false, buttonTheme = BUTTONS_THEME.outlined, style } = props
   const theme = useTheme()
 
   const getTextColor = (): Color => {
@@ -82,6 +84,7 @@ const Button = (props: ButtonProps): ReactElement => {
       backgroundColor={getBackgroundColor()}
       onPress={onPress}
       disabled={disabled}
+      style={style}
       onPressIn={() => setIsPressed(true)}
       onPressOut={() => setIsPressed(false)}>
       {/* eslint-disable-next-line react/destructuring-assignment */}

--- a/src/components/ListEmpty.tsx
+++ b/src/components/ListEmpty.tsx
@@ -1,0 +1,27 @@
+import React, { ReactElement } from 'react'
+import { Subheading } from 'react-native-paper'
+import styled from 'styled-components/native'
+
+import { SadSmileyIcon } from '../../assets/images'
+
+const ListEmptyContainer = styled.View`
+  align-items: center;
+  padding: ${props => props.theme.spacings.sm} 0;
+`
+
+const StyledSadSmileyIcon = styled(SadSmileyIcon)`
+  padding: ${props => props.theme.spacings.md} 0;
+`
+
+interface Props {
+  label: string
+}
+
+const ListEmpty = ({ label }: Props): ReactElement => (
+  <ListEmptyContainer>
+    <StyledSadSmileyIcon />
+    <Subheading>{label}</Subheading>
+  </ListEmptyContainer>
+)
+
+export default ListEmpty

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -14,7 +14,7 @@ const SearchBar = ({ query, setQuery }: Props): ReactElement => (
   <CustomTextInput
     value={query}
     onChangeText={setQuery}
-    placeholder={getLabels().dictionary.enterWord}
+    placeholder={getLabels().search.enterWord}
     rightContainer={
       <PressableOpacity onPress={() => setQuery('')}>
         {query === '' ? <MagnifierIcon /> : <CloseIcon />}

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -151,10 +151,3 @@ export const FeedbackType = {
 export type FeedbackType = typeof FeedbackType[keyof typeof FeedbackType]
 
 export const numberOfMaxRetries = 3
-
-export interface UserVocabularyDocument {
-  word: string
-  article: Article
-  imagePath: string
-  audioPath?: string
-}

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -161,7 +161,7 @@
     "words": "Wörter"
   },
   "favorites": "Favoriten",
-  "dictionary": {
+  "search": {
     "enterWord": "Wort eingeben"
   },
   "settings": {

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -146,6 +146,7 @@
     },
     "back": "Zurück",
     "plurals": "Plural",
+    "noResults": "Es wurden leider keine Ergebnisse gefunden.",
     "error": {
       "unknown": "Ein unbekannter Fehler ist aufgetreten.",
       "noWifi": "Es konnte keine Verbindung mit dem Internet hergestellt werden.",
@@ -161,8 +162,7 @@
   },
   "favorites": "Favoriten",
   "dictionary": {
-    "enterWord": "Wort eingeben",
-    "noResults": "Es wurden leider keine Ergebnisse gefunden."
+    "enterWord": "Wort eingeben"
   },
   "settings": {
     "settings": "Einstellungen",
@@ -177,12 +177,17 @@
       "disableDevMode": "Disable DevMode"
     }
   },
-  "ownVocabulary": {
+  "userVocabulary": {
     "myWords": "Meine Wörter",
+    "create": "Eigenes Wort erstellen",
     "overview": {
       "list": "Vokabelliste",
-      "create": "Vokabeln erstellen",
       "practice": "Vokabeln üben"
+    },
+    "list": {
+      "edit": "Bearbeiten",
+      "finished": "Fertig",
+      "noWordsYet": "Du hast noch keine eigenen Wörter erstellt."
     }
   }
 }

--- a/src/hooks/useReadUserVocabulary.ts
+++ b/src/hooks/useReadUserVocabulary.ts
@@ -1,0 +1,7 @@
+import { Document } from '../constants/endpoints'
+import AsyncStorage from '../services/AsyncStorage'
+import useLoadAsync, { Return } from './useLoadAsync'
+
+const useReadUserVocabulary = (): Return<Document[]> => useLoadAsync(AsyncStorage.getUserVocabulary, null)
+
+export default useReadUserVocabulary

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -79,7 +79,7 @@ const BottomTabNavigator = (): JSX.Element | null => {
       <Navigator.Screen
         name='UserVocabularyTab'
         component={UserVocabularyStackNavigator}
-        options={{ tabBarIcon: renderUserVocabularyTabIcon, title: getLabels().ownVocabulary.myWords }}
+        options={{ tabBarIcon: renderUserVocabularyTabIcon, title: getLabels().userVocabulary.myWords }}
       />
     </Navigator.Navigator>
   )

--- a/src/navigation/DictionaryStackNavigator.tsx
+++ b/src/navigation/DictionaryStackNavigator.tsx
@@ -1,7 +1,7 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
-import DictionaryDetailScreen from '../routes/DictionaryDetailScreen'
+import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import DictionaryScreen from '../routes/dictionary/DictionaryScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
@@ -22,7 +22,7 @@ const DictionaryStackNavigator = (): ReactElement => {
       />
       <Stack.Screen
         name='DictionaryDetail'
-        component={DictionaryDetailScreen}
+        component={VocabularyDetailScreen}
         options={({ navigation }) => options(back, navigation)}
       />
     </Stack.Navigator>

--- a/src/navigation/NavigationTypes.ts
+++ b/src/navigation/NavigationTypes.ts
@@ -42,6 +42,8 @@ export type RoutesParams = {
   UserVocabularyTab: undefined
   Home: undefined
   UserVocabularyOverview: undefined
+  UserVocabularyList: undefined
+  UserVocabularyDetail: { document: Document }
   ScopeSelection: {
     initialSelection: boolean
   }

--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -5,6 +5,8 @@ import { useTheme } from 'styled-components'
 
 import { useTabletHeaderHeight } from '../hooks/useTabletHeaderHeight'
 import UserVocabularyOverviewScreen from '../routes/UserVocabularyOverviewScreen'
+import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
+import UserVocabularyListScreen from '../routes/user-vocabulary-list/UserVocabularyListScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
 import screenOptions from './screenOptions'
@@ -22,6 +24,16 @@ const UserVocabularyStackNavigator = (): JSX.Element | null => {
       <Stack.Screen
         name='UserVocabularyOverview'
         component={UserVocabularyOverviewScreen}
+        options={({ navigation }) => options(overview, navigation)}
+      />
+      <Stack.Screen
+        name='UserVocabularyList'
+        component={UserVocabularyListScreen}
+        options={({ navigation }) => options(overview, navigation)}
+      />
+      <Stack.Screen
+        name='UserVocabularyDetail'
+        component={VocabularyDetailScreen}
         options={({ navigation }) => options(overview, navigation)}
       />
     </Stack.Navigator>

--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -16,7 +16,7 @@ const Stack = createStackNavigator<RoutesParams>()
 const UserVocabularyStackNavigator = (): JSX.Element | null => {
   const headerHeight = useTabletHeaderHeight(wp('15%'))
   const options = screenOptions(headerHeight)
-  const overview = getLabels().general.header.overview
+  const back = getLabels().general.back
   const theme = useTheme()
 
   return (
@@ -24,17 +24,17 @@ const UserVocabularyStackNavigator = (): JSX.Element | null => {
       <Stack.Screen
         name='UserVocabularyOverview'
         component={UserVocabularyOverviewScreen}
-        options={({ navigation }) => options(overview, navigation)}
+        options={({ navigation }) => options(back, navigation)}
       />
       <Stack.Screen
         name='UserVocabularyList'
         component={UserVocabularyListScreen}
-        options={({ navigation }) => options(overview, navigation)}
+        options={({ navigation }) => options(back, navigation)}
       />
       <Stack.Screen
         name='UserVocabularyDetail'
         component={VocabularyDetailScreen}
-        options={({ navigation }) => options(overview, navigation)}
+        options={({ navigation }) => options(back, navigation)}
       />
     </Stack.Navigator>
   )

--- a/src/routes/UserVocabularyOverviewScreen.tsx
+++ b/src/routes/UserVocabularyOverviewScreen.tsx
@@ -25,9 +25,8 @@ const Margin = styled.View`
   margin: ${props => props.theme.spacings.xl};
 `
 
-const ButtonContainer = styled.View`
-  padding: ${props => props.theme.spacings.md} 0;
-  margin: 0 auto 0;
+const StyledButton = styled(Button)`
+  margin: ${props => props.theme.spacings.md} auto;
 `
 
 interface PropsType {
@@ -50,14 +49,12 @@ const UserVocabularyOverviewScreen = ({ navigation }: PropsType): JSX.Element =>
         onPress={() => navigation.navigate('UserVocabularyOverview')}
       />
     </Root>
-    <ButtonContainer>
-      <Button
-        onPress={() => navigation.navigate('UserVocabularyOverview')}
-        label={getLabels().userVocabulary.create}
-        buttonTheme={BUTTONS_THEME.contained}
-        iconRight={AddIconWhite}
-      />
-    </ButtonContainer>
+    <StyledButton
+      onPress={() => navigation.navigate('UserVocabularyOverview')}
+      label={getLabels().userVocabulary.create}
+      buttonTheme={BUTTONS_THEME.contained}
+      iconRight={AddIconWhite}
+    />
   </RouteWrapper>
 )
 

--- a/src/routes/UserVocabularyOverviewScreen.tsx
+++ b/src/routes/UserVocabularyOverviewScreen.tsx
@@ -2,14 +2,17 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { BookIconBlack } from '../../assets/images'
+import { AddIconWhite, BookIconBlack } from '../../assets/images'
+import Button from '../components/Button'
 import ListItem from '../components/ListItem'
 import RouteWrapper from '../components/RouteWrapper'
 import { Heading } from '../components/text/Heading'
+import { BUTTONS_THEME } from '../constants/data'
 import { RoutesParams } from '../navigation/NavigationTypes'
 import { getLabels } from '../services/helpers'
 
 const Root = styled.View`
+  flex: 1;
   padding: ${props => props.theme.spacings.md};
 `
 
@@ -22,6 +25,11 @@ const Margin = styled.View`
   margin: ${props => props.theme.spacings.xl};
 `
 
+const ButtonContainer = styled.View`
+  padding: ${props => props.theme.spacings.md} 0;
+  margin: 0 auto 0;
+`
+
 interface PropsType {
   navigation: StackNavigationProp<RoutesParams, 'UserVocabularyOverview'>
 }
@@ -29,24 +37,27 @@ interface PropsType {
 const UserVocabularyOverviewScreen = ({ navigation }: PropsType): JSX.Element => (
   <RouteWrapper>
     <Root>
-      <StyledHeading>{getLabels().ownVocabulary.myWords}</StyledHeading>
+      <StyledHeading>{getLabels().userVocabulary.myWords}</StyledHeading>
       <Margin />
       <ListItem
         icon={<BookIconBlack />}
-        title={getLabels().ownVocabulary.overview.list}
-        onPress={() => navigation.navigate('UserVocabularyOverview')}
+        title={getLabels().userVocabulary.overview.list}
+        onPress={() => navigation.navigate('UserVocabularyList')}
       />
       <ListItem
         icon={<BookIconBlack />}
-        title={getLabels().ownVocabulary.overview.create}
-        onPress={() => navigation.navigate('UserVocabularyOverview')}
-      />
-      <ListItem
-        icon={<BookIconBlack />}
-        title={getLabels().ownVocabulary.overview.practice}
+        title={getLabels().userVocabulary.overview.practice}
         onPress={() => navigation.navigate('UserVocabularyOverview')}
       />
     </Root>
+    <ButtonContainer>
+      <Button
+        onPress={() => navigation.navigate('UserVocabularyOverview')}
+        label={getLabels().userVocabulary.create}
+        buttonTheme={BUTTONS_THEME.contained}
+        iconRight={AddIconWhite}
+      />
+    </ButtonContainer>
   </RouteWrapper>
 )
 

--- a/src/routes/VocabularyDetailScreen.tsx
+++ b/src/routes/VocabularyDetailScreen.tsx
@@ -9,7 +9,7 @@ interface Props {
   route: RouteProp<RoutesParams, 'DictionaryDetail'>
 }
 
-const DictionaryDetailScreen = ({ route }: Props): ReactElement => {
+const VocabularyDetailScreen = ({ route }: Props): ReactElement => {
   const { document } = route.params
   return (
     <RouteWrapper>
@@ -18,4 +18,4 @@ const DictionaryDetailScreen = ({ route }: Props): ReactElement => {
   )
 }
 
-export default DictionaryDetailScreen
+export default VocabularyDetailScreen

--- a/src/routes/__tests__/UserVocabularyOverviewScreen.spec.tsx
+++ b/src/routes/__tests__/UserVocabularyOverviewScreen.spec.tsx
@@ -9,9 +9,9 @@ describe('UserVocabularyOverviewScreen', () => {
   const navigation = createNavigationMock<'UserVocabularyOverview'>()
   it('should show content', () => {
     const { getByText } = render(<UserVocabularyOverviewScreen navigation={navigation} />)
-    expect(getByText(getLabels().ownVocabulary.myWords)).toBeDefined()
-    expect(getByText(getLabels().ownVocabulary.overview.list)).toBeDefined()
-    expect(getByText(getLabels().ownVocabulary.overview.create)).toBeDefined()
-    expect(getByText(getLabels().ownVocabulary.overview.practice)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.myWords)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.overview.list)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.create)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.overview.practice)).toBeDefined()
   })
 })

--- a/src/routes/dictionary/DictionaryScreen.tsx
+++ b/src/routes/dictionary/DictionaryScreen.tsx
@@ -1,33 +1,21 @@
 import { StackNavigationProp } from '@react-navigation/stack'
-import normalizeStrings from 'normalize-strings'
 import React, { ReactElement, useState } from 'react'
 import { FlatList } from 'react-native'
-import { Subheading } from 'react-native-paper'
 import styled from 'styled-components/native'
 
-import { SadSmileyIcon } from '../../../assets/images'
+import ListEmpty from '../../components/ListEmpty'
 import RouteWrapper from '../../components/RouteWrapper'
 import SearchBar from '../../components/SearchBar'
 import ServerResponseHandler from '../../components/ServerResponseHandler'
 import Title from '../../components/Title'
-import { ARTICLES } from '../../constants/data'
 import { Document } from '../../constants/endpoints'
 import useLoadAllDocuments from '../../hooks/useLoadAllDocuments'
 import { RoutesParams } from '../../navigation/NavigationTypes'
-import { getLabels } from '../../services/helpers'
+import { getLabels, getSortedAndFilteredDocuments, matchAlternative } from '../../services/helpers'
 import DictionaryItem from './components/DictionaryItem'
 
 const Root = styled.View`
   padding: 0 ${props => props.theme.spacings.sm};
-`
-
-const ListEmptyContainer = styled.View`
-  align-items: center;
-  padding: ${props => props.theme.spacings.sm} 0;
-`
-
-const StyledSadSmileyIcon = styled(SadSmileyIcon)`
-  padding: ${props => props.theme.spacings.md} 0;
 `
 
 const Header = styled.View`
@@ -42,24 +30,10 @@ const DictionaryScreen = ({ navigation }: Props): ReactElement => {
   const documents = useLoadAllDocuments()
   const [searchString, setSearchString] = useState<string>('')
 
-  const searchStringWithoutArticle = ARTICLES.map(article => article.value).includes(
-    searchString.split(' ')[0].toLowerCase()
-  )
-    ? searchString.substring(searchString.indexOf(' ') + 1)
-    : searchString
-  const normalizedSearchString = normalizeStrings(searchStringWithoutArticle).toLowerCase().trim()
+  const sortedAndFilteredDocuments = getSortedAndFilteredDocuments(documents.data, searchString)
 
-  const matchAlternative = (document: Document): boolean =>
-    document.alternatives.filter(alternative => alternative.word.toLowerCase().includes(normalizedSearchString))
-      .length > 0
-
-  const filteredDocuments = documents.data?.filter(
-    item => item.word.toLowerCase().includes(normalizedSearchString) || matchAlternative(item)
-  )
-  const sortedDocuments = filteredDocuments?.sort((a, b) => a.word.localeCompare(b.word))
-
-  const description = `${filteredDocuments?.length ?? 0} ${
-    (filteredDocuments?.length ?? 0) === 1 ? getLabels().general.word : getLabels().general.words
+  const description = `${sortedAndFilteredDocuments.length} ${
+    sortedAndFilteredDocuments.length === 1 ? getLabels().general.word : getLabels().general.words
   }`
 
   const navigateToDetail = (document: Document): void => {
@@ -79,21 +53,16 @@ const DictionaryScreen = ({ navigation }: Props): ReactElement => {
                   <SearchBar query={searchString} setQuery={setSearchString} />
                 </Header>
               }
-              data={sortedDocuments}
+              data={sortedAndFilteredDocuments}
               renderItem={({ item }) => (
                 <DictionaryItem
                   document={item}
-                  showAlternatives={matchAlternative(item) && searchString.length > 0}
+                  showAlternatives={matchAlternative(item, searchString) && searchString.length > 0}
                   navigateToDetail={navigateToDetail}
                 />
               )}
               showsVerticalScrollIndicator={false}
-              ListEmptyComponent={
-                <ListEmptyContainer>
-                  <StyledSadSmileyIcon />
-                  <Subheading>{getLabels().dictionary.noResults}</Subheading>
-                </ListEmptyContainer>
-              }
+              ListEmptyComponent={<ListEmpty label={getLabels().general.noResults} />}
             />
           )}
         </Root>

--- a/src/routes/dictionary/__tests__/DictionaryScreen.spec.tsx
+++ b/src/routes/dictionary/__tests__/DictionaryScreen.spec.tsx
@@ -31,7 +31,7 @@ describe('DictionaryScreen', () => {
     const { getByText, getByPlaceholderText } = render(<DictionaryScreen navigation={navigation} />)
     expect(getByText(getLabels().general.dictionary)).toBeDefined()
     expect(getByText(`4 ${getLabels().general.words}`)).toBeDefined()
-    expect(getByPlaceholderText(getLabels().dictionary.enterWord)).toBeDefined()
+    expect(getByPlaceholderText(getLabels().search.enterWord)).toBeDefined()
     expect(getByText(documents[0].word)).toBeDefined()
     expect(getByText(documents[1].word)).toBeDefined()
     expect(getByText(documents[2].word)).toBeDefined()
@@ -41,7 +41,7 @@ describe('DictionaryScreen', () => {
   it('should filter by word', () => {
     mocked(useLoadAllDocuments).mockReturnValue(getReturnOf(documents))
     const { queryByText, getByPlaceholderText } = render(<DictionaryScreen navigation={navigation} />)
-    const searchBar = getByPlaceholderText(getLabels().dictionary.enterWord)
+    const searchBar = getByPlaceholderText(getLabels().search.enterWord)
     fireEvent.changeText(searchBar, documents[0].word)
     expect(queryByText(documents[0].word)).toBeDefined()
     expect(queryByText(documents[1].word)).toBeNull()
@@ -52,7 +52,7 @@ describe('DictionaryScreen', () => {
   it('should filter by word and article', () => {
     mocked(useLoadAllDocuments).mockReturnValue(getReturnOf(documents))
     const { queryByText, getByPlaceholderText } = render(<DictionaryScreen navigation={navigation} />)
-    const searchBar = getByPlaceholderText(getLabels().dictionary.enterWord)
+    const searchBar = getByPlaceholderText(getLabels().search.enterWord)
     fireEvent.changeText(searchBar, `${documents[0].article.value} ${documents[0].word}`)
     expect(queryByText(documents[0].word)).toBeDefined()
     expect(queryByText(documents[1].word)).toBeNull()

--- a/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
+++ b/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
@@ -1,0 +1,94 @@
+import { StackNavigationProp } from '@react-navigation/stack'
+import React, { ReactElement, useState } from 'react'
+import { FlatList } from 'react-native'
+import styled from 'styled-components/native'
+
+import { AddIconWhite } from '../../../assets/images'
+import Button from '../../components/Button'
+import RouteWrapper from '../../components/RouteWrapper'
+import SearchBar from '../../components/SearchBar'
+import Title from '../../components/Title'
+import VocabularyListItem from '../../components/VocabularyListItem'
+import { ContentTextBold } from '../../components/text/Content'
+import { BUTTONS_THEME } from '../../constants/data'
+import { Document } from '../../constants/endpoints'
+import { useIsKeyboardVisible } from '../../hooks/useIsKeyboardVisible'
+import useLoadAsync from '../../hooks/useLoadAsync'
+import { RoutesParams } from '../../navigation/NavigationTypes'
+import AsyncStorage from '../../services/AsyncStorage'
+import { getLabels, getSortedAndFilteredDocuments } from '../../services/helpers'
+import ListEmptyContent from './components/ListEmptyContent'
+
+const Root = styled.View`
+  padding: 0 ${props => props.theme.spacings.sm};
+`
+
+const EditPressable = styled.Pressable`
+  align-self: flex-end;
+  padding: ${props => props.theme.spacings.sm} 0;
+`
+
+const ButtonContainer = styled.View`
+  padding-bottom: ${props => props.theme.spacings.sm};
+  position: absolute;
+  align-self: center;
+  bottom: 0px;
+`
+
+interface Props {
+  navigation: StackNavigationProp<RoutesParams, 'UserVocabularyList'>
+}
+
+const UserVocabularyListScreen = ({ navigation }: Props): ReactElement => {
+  const documents = useLoadAsync(AsyncStorage.getUserVocabulary, {})
+  const [searchString, setSearchString] = useState<string>('')
+  const isKeyboardVisible = useIsKeyboardVisible()
+
+  const numberOfDocuments = documents.data?.length ?? 0
+  const sortedAndFilteredDocuments = getSortedAndFilteredDocuments(documents.data, searchString)
+
+  const navigateToDetail = (document: Document): void => {
+    navigation.navigate('UserVocabularyDetail', { document })
+  }
+
+  return (
+    <RouteWrapper>
+      <Root>
+        <FlatList
+          keyboardShouldPersistTaps='handled'
+          contentContainerStyle={{ paddingBottom: 100 }}
+          ListHeaderComponent={
+            <>
+              <Title
+                title={getLabels().userVocabulary.myWords}
+                description={`${numberOfDocuments} ${
+                  numberOfDocuments === 1 ? getLabels().general.word : getLabels().general.words
+                }`}
+              />
+              <SearchBar query={searchString} setQuery={setSearchString} />
+              <EditPressable>
+                <ContentTextBold>{getLabels().userVocabulary.list.edit}</ContentTextBold>
+              </EditPressable>
+            </>
+          }
+          data={sortedAndFilteredDocuments}
+          renderItem={({ item }) => <VocabularyListItem document={item} onPress={() => navigateToDetail(item)} />}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={<ListEmptyContent documents={documents} />}
+        />
+        {!isKeyboardVisible && (
+          <ButtonContainer>
+            <Button
+              onPress={() => navigation.navigate('UserVocabularyOverview')}
+              label={getLabels().userVocabulary.create}
+              buttonTheme={BUTTONS_THEME.contained}
+              iconRight={AddIconWhite}
+            />
+          </ButtonContainer>
+        )}
+      </Root>
+    </RouteWrapper>
+  )
+}
+
+export default UserVocabularyListScreen

--- a/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
+++ b/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
@@ -13,9 +13,8 @@ import { ContentTextBold } from '../../components/text/Content'
 import { BUTTONS_THEME } from '../../constants/data'
 import { Document } from '../../constants/endpoints'
 import { useIsKeyboardVisible } from '../../hooks/useIsKeyboardVisible'
-import useLoadAsync from '../../hooks/useLoadAsync'
+import useReadUserVocabulary from '../../hooks/useReadUserVocabulary'
 import { RoutesParams } from '../../navigation/NavigationTypes'
-import AsyncStorage from '../../services/AsyncStorage'
 import { getLabels, getSortedAndFilteredDocuments } from '../../services/helpers'
 import ListEmptyContent from './components/ListEmptyContent'
 
@@ -40,7 +39,7 @@ interface Props {
 }
 
 const UserVocabularyListScreen = ({ navigation }: Props): ReactElement => {
-  const documents = useLoadAsync(AsyncStorage.getUserVocabulary, {})
+  const documents = useReadUserVocabulary()
   const [searchString, setSearchString] = useState<string>('')
   const isKeyboardVisible = useIsKeyboardVisible()
 

--- a/src/routes/user-vocabulary-list/__tests__/UserVocabularyListScreen.spec.tsx
+++ b/src/routes/user-vocabulary-list/__tests__/UserVocabularyListScreen.spec.tsx
@@ -1,0 +1,48 @@
+import { mocked } from 'jest-mock'
+import React from 'react'
+
+import useReadUserVocabulary from '../../../hooks/useReadUserVocabulary'
+import { getLabels } from '../../../services/helpers'
+import DocumentBuilder from '../../../testing/DocumentBuilder'
+import createNavigationMock from '../../../testing/createNavigationPropMock'
+import { getReturnOf } from '../../../testing/helper'
+import render from '../../../testing/render'
+import UserVocabularyListScreen from '../UserVocabularyListScreen'
+
+jest.mock('../../../hooks/useReadUserVocabulary')
+
+jest.mock('../../../components/FavoriteButton', () => () => {
+  const { Text } = require('react-native')
+  return <Text>FavoriteButton</Text>
+})
+
+jest.mock('../../../components/AudioPlayer', () => () => {
+  const { Text } = require('react-native')
+  return <Text>AudioPlayer</Text>
+})
+
+describe('UserVocabularyListScreen', () => {
+  const navigation = createNavigationMock<'UserVocabularyList'>()
+  const userDocuments = new DocumentBuilder(2).build()
+
+  it('should render list correctly', () => {
+    mocked(useReadUserVocabulary).mockReturnValue(getReturnOf(userDocuments))
+    const { getByText, getByPlaceholderText } = render(<UserVocabularyListScreen navigation={navigation} />)
+
+    expect(getByText(`2 ${getLabels().general.words}`)).toBeDefined()
+    expect(getByPlaceholderText(getLabels().search.enterWord)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.list.edit)).toBeDefined()
+    expect(getByText(userDocuments[0].word)).toBeDefined()
+    expect(getByText(userDocuments[1].word)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.create)).toBeDefined()
+  })
+
+  it('should render empty list correctly', () => {
+    mocked(useReadUserVocabulary).mockReturnValue(getReturnOf([]))
+    const { getByText } = render(<UserVocabularyListScreen navigation={navigation} />)
+
+    expect(getByText(`0 ${getLabels().general.words}`)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.list.noWordsYet)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.create)).toBeDefined()
+  })
+})

--- a/src/routes/user-vocabulary-list/components/ListEmptyContent.tsx
+++ b/src/routes/user-vocabulary-list/components/ListEmptyContent.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from 'react'
+import { widthPercentageToDP as wp } from 'react-native-responsive-screen'
+import styled from 'styled-components/native'
+
+import ListEmpty from '../../../components/ListEmpty'
+import Loading from '../../../components/Loading'
+import { Document } from '../../../constants/endpoints'
+import { Return } from '../../../hooks/useLoadAsync'
+import { getLabels } from '../../../services/helpers'
+
+const EmptyContainer = styled.View`
+  height: ${wp('20%')}px;
+`
+
+interface Props {
+  documents: Return<Document[]>
+}
+
+const ListEmptyContent = ({ documents }: Props): ReactElement => {
+  if (documents.loading) {
+    return (
+      <EmptyContainer>
+        <Loading isLoading={documents.loading} />
+      </EmptyContainer>
+    )
+  }
+  return documents.data?.length === 0 ? (
+    <ListEmpty label={getLabels().userVocabulary.list.noWordsYet} />
+  ) : (
+    <ListEmpty label={getLabels().general.noResults} />
+  )
+}
+
+export default ListEmptyContent

--- a/src/services/AsyncStorage.ts
+++ b/src/services/AsyncStorage.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
-import { ExerciseKey, Progress, UserVocabularyDocument } from '../constants/data'
+import { ExerciseKey, Progress } from '../constants/data'
+import { Document } from '../constants/endpoints'
 import { DocumentResult } from '../navigation/NavigationTypes'
 import { CMS, productionCMS, testCMS } from './axios'
 
@@ -141,24 +142,22 @@ const getDevMode = async (): Promise<boolean | null> => {
   return isDevMode ? JSON.parse(isDevMode) : null
 }
 
-const getUserVocabulary = async (): Promise<UserVocabularyDocument[]> => {
+const getUserVocabulary = async (): Promise<Document[]> => {
   const userVocabulary = await AsyncStorage.getItem(USER_VOCABULARY)
   return userVocabulary ? JSON.parse(userVocabulary) : []
 }
 
-const setUserVocabulary = async (userDocument: UserVocabularyDocument[]): Promise<void> => {
+const setUserVocabulary = async (userDocument: Document[]): Promise<void> => {
   await AsyncStorage.setItem(USER_VOCABULARY, JSON.stringify(userDocument))
 }
 
-const addUserDocument = async (userDocument: UserVocabularyDocument): Promise<void> => {
+const addUserDocument = async (userDocument: Document): Promise<void> => {
+  console.log('add: ', userDocument.word)
   const userVocabulary = await getUserVocabulary()
   await setUserVocabulary([...userVocabulary, userDocument])
 }
 
-const editUserDocument = async (
-  oldUserDocument: UserVocabularyDocument,
-  newUserDocument: UserVocabularyDocument
-): Promise<boolean> => {
+const editUserDocument = async (oldUserDocument: Document, newUserDocument: Document): Promise<boolean> => {
   const userVocabulary = await getUserVocabulary()
   const index = userVocabulary.findIndex(item => JSON.stringify(item) === JSON.stringify(oldUserDocument))
   if (index === -1) {
@@ -169,7 +168,8 @@ const editUserDocument = async (
   return true
 }
 
-const deleteUserDocument = async (userDocument: UserVocabularyDocument): Promise<void> => {
+const deleteUserDocument = async (userDocument: Document): Promise<void> => {
+  console.log('delete')
   const userVocabulary = getUserVocabulary().then(vocab =>
     vocab.filter(item => JSON.stringify(item) !== JSON.stringify(userDocument))
   )

--- a/src/services/__tests__/AsyncStorage.spec.ts
+++ b/src/services/__tests__/AsyncStorage.spec.ts
@@ -1,4 +1,4 @@
-import { ARTICLES, ExerciseKeys, Progress, SIMPLE_RESULTS } from '../../constants/data'
+import { ExerciseKeys, Progress, SIMPLE_RESULTS } from '../../constants/data'
 import { DocumentResult } from '../../navigation/NavigationTypes'
 import DocumentBuilder from '../../testing/DocumentBuilder'
 import { mockDisciplines } from '../../testing/mockDiscipline'
@@ -121,39 +121,29 @@ describe('AsyncStorage', () => {
   })
 
   describe('userVocabulary', () => {
-    const userDocument1 = {
-      word: 'Helm',
-      article: ARTICLES[1],
-      imagePath: 'pathToImage1',
-    }
-
-    const userDocument2 = {
-      word: 'Jacke',
-      article: ARTICLES[2],
-      imagePath: 'pathToImage1',
-    }
+    const userDocuments = new DocumentBuilder(2).build()
 
     it('should add userDocument', async () => {
       const userVocabulary = await AsyncStorage.getUserVocabulary()
       expect(userVocabulary).toHaveLength(0)
-      await AsyncStorage.addUserDocument(userDocument1)
+      await AsyncStorage.addUserDocument(userDocuments[0])
       const updatedUserVocabulary = await AsyncStorage.getUserVocabulary()
       expect(updatedUserVocabulary).toHaveLength(1)
     })
 
     it('should edit userDocument', async () => {
-      await AsyncStorage.addUserDocument(userDocument1)
-      await AsyncStorage.editUserDocument(userDocument1, userDocument2)
+      await AsyncStorage.addUserDocument(userDocuments[0])
+      await AsyncStorage.editUserDocument(userDocuments[0], userDocuments[1])
       const updatedUserVocabulary = await AsyncStorage.getUserVocabulary()
       expect(updatedUserVocabulary).toHaveLength(1)
-      expect(updatedUserVocabulary[0]).toEqual(userDocument2)
+      expect(updatedUserVocabulary[0]).toEqual(userDocuments[1])
     })
 
     it('should delete userDocument', async () => {
-      await AsyncStorage.addUserDocument(userDocument1)
+      await AsyncStorage.addUserDocument(userDocuments[0])
       const userVocabulary = await AsyncStorage.getUserVocabulary()
       expect(userVocabulary).toHaveLength(1)
-      await AsyncStorage.deleteUserDocument(userDocument1)
+      await AsyncStorage.deleteUserDocument(userDocuments[0])
       const updatedUserVocabulary = await AsyncStorage.getUserVocabulary()
       expect(updatedUserVocabulary).toHaveLength(0)
     })

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios'
+import normalizeStrings from 'normalize-strings'
 
-import { Article, EXERCISES, FeedbackType, NextExercise, Progress } from '../constants/data'
+import { Article, ARTICLES, EXERCISES, FeedbackType, NextExercise, Progress } from '../constants/data'
 import { AlternativeWord, Discipline, Document, ENDPOINTS } from '../constants/endpoints'
 import labels from '../constants/labels.json'
 import { COLORS } from '../constants/theme/colors'
@@ -140,3 +141,26 @@ export const sendFeedback = (comment: string, feedbackType: FeedbackType, id: nu
     content_type: feedbackType,
     object_id: id,
   })
+
+const normalizeSearchString = (searchString: string): string => {
+  const searchStringWithoutArticle = ARTICLES.map(article => article.value).includes(
+    searchString.split(' ')[0].toLowerCase()
+  )
+    ? searchString.substring(searchString.indexOf(' ') + 1)
+    : searchString
+  return normalizeStrings(searchStringWithoutArticle).toLowerCase().trim()
+}
+
+export const matchAlternative = (document: Document, searchString: string): boolean =>
+  document.alternatives.filter(alternative =>
+    alternative.word.toLowerCase().includes(normalizeSearchString(searchString))
+  ).length > 0
+
+export const getSortedAndFilteredDocuments = (documents: Document[] | null, searchString: string): Document[] => {
+  const normalizedSearchString = normalizeSearchString(searchString)
+
+  const filteredDocuments = documents?.filter(
+    item => item.word.toLowerCase().includes(normalizedSearchString) || matchAlternative(item, normalizedSearchString)
+  )
+  return filteredDocuments?.sort((a, b) => a.word.localeCompare(b.word)) ?? []
+}


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.

To test this, you need to add some data to AsyncStorage:
```
const a = new DocumentBuild(4).build()
AsyncStorage.addUserDocument({...a[0]})
....
```
and so on..
