### PR TITLE
LUN-447: Fix overlap on choice exercises

### DIFF
--- a/release-notes/unreleased/LUN-447-fix-overlap.yml
+++ b/release-notes/unreleased/LUN-447-fix-overlap.yml
@@ -3,4 +3,4 @@ show_in_stores: true
 platforms:
   - android
   - ios
-de: Die Übungen werden jetzt auch auf niedrigen Bildschirmen richtig angezeigt
+de: Die Übungen werden jetzt auch auf Bildschirmen mit niedriger Auflösung korrekt angezeigt

--- a/release-notes/unreleased/LUN-447-fix-overlap.yml
+++ b/release-notes/unreleased/LUN-447-fix-overlap.yml
@@ -1,0 +1,6 @@
+issue_key: LUN-447
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Die Übungen werden jetzt auch auf niedrigen Bildschirmen richtig angezeigt

--- a/src/routes/choice-exercises/components/SingleChoiceExercise.tsx
+++ b/src/routes/choice-exercises/components/SingleChoiceExercise.tsx
@@ -1,6 +1,7 @@
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { ReactElement, useCallback, useEffect, useState } from 'react'
+import { ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ArrowRightIcon } from '../../../../assets/images'
@@ -157,7 +158,7 @@ const ChoiceExerciseScreen = ({
         exerciseKey={exerciseKey}
       />
 
-      <>
+      <ScrollView>
         <VocabularyItemImageSection vocabularyItem={vocabularyItem} audioDisabled={selectedAnswer === null} />
         <SingleChoice
           answers={answers}
@@ -186,7 +187,7 @@ const ChoiceExerciseScreen = ({
           )}
           <CheatMode cheat={onExerciseCheated} />
         </ButtonContainer>
-      </>
+      </ScrollView>
     </>
   )
 }


### PR DESCRIPTION
This pull request belongs to the issue https://issues.tuerantuer.org/browse/LUN-447 .

Screenshot from a Nexus S:
<img width="287" alt="image" src="https://user-images.githubusercontent.com/18513943/206478127-61c4f0cd-1c15-4457-97f5-d76035b00614.png">

