### PR TITLE
LUN-450: write tests for NotAuthorizedView

### DIFF
--- a/src/components/__tests__/NotAuthorisedView.spec.tsx
+++ b/src/components/__tests__/NotAuthorisedView.spec.tsx
@@ -1,0 +1,43 @@
+import { fireEvent } from '@testing-library/react-native'
+import { mocked } from 'jest-mock'
+import React from 'react'
+import { Linking } from 'react-native'
+
+import { getLabels } from '../../services/helpers'
+import render from '../../testing/render'
+import NotAuthorisedView from '../NotAuthorisedView'
+
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openSettings: jest.fn(),
+}))
+
+describe('NotAuthorisedView', () => {
+  const setVisible = jest.fn()
+
+  it('should render description', () => {
+    const { getByText } = render(
+      <NotAuthorisedView setVisible={setVisible} description={getLabels().general.camera.noAuthorization.description} />
+    )
+    const isNoAuthDescription = getByText(getLabels().general.camera.noAuthorization.description)
+    expect(isNoAuthDescription).toBeTruthy()
+  })
+
+  it('should successfully go back', () => {
+    const { getByText } = render(
+      <NotAuthorisedView setVisible={setVisible} description={getLabels().general.camera.noAuthorization.description} />
+    )
+    const buttonVisible = getByText(getLabels().general.back)
+    fireEvent.press(buttonVisible)
+    expect(getByText(getLabels().general.back)).toBeDefined()
+  })
+
+  it('should open settings successfully', () => {
+    mocked(Linking.openSettings).mockImplementationOnce(Promise.resolve)
+    const { getByText } = render(
+      <NotAuthorisedView setVisible={setVisible} description={getLabels().general.camera.noAuthorization.description} />
+    )
+    const message = getByText(getLabels().settings.settings)
+    fireEvent.press(message)
+    expect(Linking.openSettings).toBeDefined()
+  })
+})


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.tuerantuer.org/secure/RapidBoard.jspa?rapidView=27&view=detail).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword _LUN_.
