### PR TITLE
LUN-472: Dependabot vulnerability alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    jmespath (1.4.0)
+    jmespath (1.6.2)
     json (2.5.1)
     jwt (2.2.2)
     memoist (0.16.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.1.1)
@@ -145,7 +145,7 @@ GEM
     naturally (2.2.1)
     os (1.1.1)
     plist (3.6.0)
-    public_suffix (4.0.6)
+    public_suffix (5.0.1)
     rake (13.0.3)
     representable (3.1.0)
       declarative (< 0.1.0)
@@ -199,4 +199,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   2.2.16
+   2.2.21

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.1.1)
@@ -156,7 +156,7 @@ GEM
     netrc (0.11.0)
     os (1.1.1)
     plist (3.6.0)
-    public_suffix (4.0.6)
+    public_suffix (5.0.1)
     rake (13.0.3)
     representable (3.1.1)
       declarative (< 0.1.0)

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    jmespath (1.4.0)
+    jmespath (1.6.2)
     json (2.5.1)
     jwt (2.2.3)
     memoist (0.16.2)

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.7)
+    activesupport (6.1.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -75,7 +75,7 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     declarative (0.0.20)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
@@ -215,7 +215,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    minitest (5.16.3)
+    minitest (5.18.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -262,7 +262,7 @@ GEM
       tty-cursor (~> 0.7)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf (0.1.4)
@@ -282,7 +282,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   arm64-darwin-22

--- a/release-notes/LUN-472-security-updates.yml
+++ b/release-notes/LUN-472-security-updates.yml
@@ -1,0 +1,6 @@
+issue_key: LUN-472
+show_in_stores: false
+platforms:
+  - android
+  - ios
+de: Einige Pakete von dritten Parteien sind nun auf dem neuesten Stand.

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -369,11 +369,11 @@ __metadata:
   linkType: hard
 
 "@types/jsonwebtoken@npm:^8.3.3":
-  version: 8.5.8
-  resolution: "@types/jsonwebtoken@npm:8.5.8"
+  version: 9.0.0
+  resolution: "@types/jsonwebtoken@npm:9.0.0"
   dependencies:
     "@types/node": "*"
-  checksum: 78b614aa06cb83e6751680448b78daac36bc8f24f7f52b7922e01295ff4b6c2917973e9a359de4219fcc274813f3ae1edc864771dab6cb1de5b68ff8d3d5d611
+  checksum: 168636cad4dc02b7e42ffa7ac71ca93911f783e8478c854194f3adf6ab518a57a19f620f8c3a9ec2a8a8016f7c613d34c9ee004e516c648471c7fb3c98804672
   languageName: node
   linkType: hard
 
@@ -805,8 +805,8 @@ __metadata:
   linkType: hard
 
 "jsonwebtoken@npm:^8.5.1":
-  version: 8.5.1
-  resolution: "jsonwebtoken@npm:8.5.1"
+  version: 9.0.0
+  resolution: "jsonwebtoken@npm:9.0.0"
   dependencies:
     jws: ^3.2.2
     lodash.includes: ^4.3.0
@@ -818,7 +818,7 @@ __metadata:
     lodash.once: ^4.0.0
     ms: ^2.1.1
     semver: ^5.6.0
-  checksum: c5ad937b6fa23a230efa8ed8ca3c0da8ebfdd377bafc3e8432a11b03ef90e733400a00b26c0dfee47db44a2e64b88b154b57e9926a92990f98dd25aaed15006e
+  checksum: 60c30d90d8a69b8e7148306e0c299ac120dbde9c032add48d26df928fe349e952cf4b09f12d7942257681a936e3374e4d49280ab20f8a4578688c7f08d87f9bc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9716,11 +9716,11 @@ __metadata:
   linkType: hard
 
 "json5@npm:2.x, json5@npm:^2.1.2, json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
+  version: 2.2.2
+  resolution: "json5@npm:2.2.2"
   bin:
     json5: lib/cli.js
-  checksum: a7174bc4e146613750a04a8a7fe2bc4ab6f4cad20486f8d7026cc4546b3ee1dc3762fc5e7377557ae99414745aac782486e409f31c363084a455e05cb495ce7a
+  checksum: 3e145dd8a0aa96c305904539817b6564e776e26672b0e6107cd65cfb65fd452b8aa7f322fb17f395d0256834a0c68bbfdece503975e90f97fa8a2111e1af8932
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request belongs to https://issues.tuerantuer.org/browse/LUN-472. It fixes the vulnerability alerts that Dependabot can't fix by itself.
