### PR TITLE
699: remove trailing slash workaround

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -284,6 +284,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   cocoapods (= 1.12.1)

--- a/src/services/__tests__/axios.spec.ts
+++ b/src/services/__tests__/axios.spec.ts
@@ -20,7 +20,7 @@ describe('getFromEndpoint', () => {
     const responseData = await getFromEndpoint(path)
     expect(responseData).toBe(data)
     expect(axios.get).toHaveBeenCalledTimes(1)
-    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc/', { headers: undefined })
+    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc', { headers: undefined })
   })
 
   it('should include api key in header', async () => {
@@ -31,7 +31,7 @@ describe('getFromEndpoint', () => {
     const apiKey = 'my_api_key'
     await getFromEndpoint(path, apiKey)
     expect(axios.get).toHaveBeenCalledTimes(1)
-    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc/', {
+    expect(axios.get).toHaveBeenCalledWith('https://lunes-test.tuerantuer.org/api/abc', {
       headers: { Authorization: `Api-Key ${apiKey}` },
     })
   })

--- a/src/services/__tests__/url.spec.ts
+++ b/src/services/__tests__/url.spec.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'jest-mock'
 import { Linking } from 'react-native'
 
-import { addTrailingSlashToUrl, openExternalUrl } from '../url'
+import { openExternalUrl } from '../url'
 
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
   canOpenURL: jest.fn(),
@@ -19,17 +19,5 @@ describe('url', () => {
 
     expect(Linking.canOpenURL).toHaveBeenCalledWith(url)
     expect(Linking.openURL).toHaveBeenCalledWith(url)
-  })
-
-  it('should add trailing slash to url', () => {
-    const url = 'https://lunes-app.de'
-
-    expect(addTrailingSlashToUrl(url)).toBe('https://lunes-app.de/')
-  })
-
-  it('should not add trailing slash to url', () => {
-    const url = 'https://lunes-app.de/'
-
-    expect(addTrailingSlashToUrl(url)).toBe('https://lunes-app.de/')
   })
 })

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -2,7 +2,6 @@ import axios, { AxiosResponse } from 'axios'
 import { buildKeyGenerator, setupCache } from 'axios-cache-interceptor'
 
 import { getOverwriteCMS } from './AsyncStorage'
-import { addTrailingSlashToUrl } from './url'
 
 export const testCMS = 'https://lunes-test.tuerantuer.org/api'
 export const productionCMS = 'https://lunes.tuerantuer.org/api'
@@ -30,7 +29,7 @@ setupCache(axios, {
 
 const getUrl = async (endpoint: string): Promise<string> => {
   const baseURL = await getBaseURL()
-  return `${baseURL}/${addTrailingSlashToUrl(endpoint)}`
+  return `${baseURL}/${endpoint}`
 }
 
 export const getFromEndpoint = async <T>(endpoint: string, apiKey?: string): Promise<T> => {

--- a/src/services/url.ts
+++ b/src/services/url.ts
@@ -2,9 +2,6 @@ import { Linking } from 'react-native'
 
 import { log } from './sentry'
 
-// fix ios issue for Django, that requires trailing slash in request url https://github.com/square/retrofit/issues/1037
-export const addTrailingSlashToUrl = (url: string): string => (url.endsWith('/') ? url : `${url}/`)
-
 export const openExternalUrl = (url: string): Promise<void> =>
   Linking.canOpenURL(url)
     .then(supported => {


### PR DESCRIPTION
### Short description

Remove a workaround that adds a trailing slash to each api request.

### Proposed changes

<!-- Describe this PR in more detail. -->

- remove workaround

### Side effects

N/A

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->
Fixes: #669

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
