### PR TITLE
990: Update macos resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
             TOTAL_CPUS: 4
         macos:
             xcode: 14.2.0
-        resource_class: medium
+        resource_class: macos.m1.medium.gen1
         shell: /bin/bash --login -o pipefail
         steps:
             - add_ssh_keys:

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,10 +1,10 @@
 macos:
   xcode: 14.2.0
-resource_class: medium
+resource_class: macos.m1.medium.gen1
 environment:
   FL_OUTPUT_DIR: output
   FASTLANE_SKIP_UPDATE_CHECK: true
-  TOTAL_CPUS: 4 # For mac with resource_class medium, used in metro.config.ci.js.
+  TOTAL_CPUS: 4 # For mac with resource_class macos.m1.medium.gen1, used in metro.config.ci.js.
 shell: /bin/bash --login -o pipefail
 steps:
   - add_ssh_keys: # Needed for credentials repo


### PR DESCRIPTION
### Short description

Switch from old deprecated x86 to m1 resource class because tests will fail in the end of the year

### Proposed changes

Switch resource classes for ios builds if deprecated resource are in use

resolves #990 