### PR TITLE
Unify apple account used for app signing

### DIFF
--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -4,4 +4,4 @@
 
 
 app_identifier("app.lunes") # The bundle identifier of your app
-apple_id("delivery@lunes.app") # Your Apple email address
+apple_id("app-team@integreat-app.de") # Your Apple email address


### PR DESCRIPTION
### Short description
Changed the app store mail to be the same as for all other apps, as this makes the regular updates of the certificates easier and we are more likely not to look us out from our shared accounts, as they can be quite a pain, because of how the 2FA works.