### PR TITLE
921: Add searching for professions

### DIFF
--- a/release-notes/unreleased/921-search-for-profession.yml
+++ b/release-notes/unreleased/921-search-for-profession.yml
@@ -1,0 +1,6 @@
+issue_key: 921
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Man kann nun nach Berufen suchen

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -8,16 +8,17 @@ import CustomTextInput from './CustomTextInput'
 type SearchBarProps = {
   query: string
   setQuery: (input: string) => void
+  placeholder?: string
 }
 
-const SearchBar = ({ query, setQuery }: SearchBarProps): ReactElement => {
+const SearchBar = ({ query, setQuery, placeholder = getLabels().search.enterWord }: SearchBarProps): ReactElement => {
   const theme = useTheme()
   return (
     <CustomTextInput
       value={query}
       clearable
       onChangeText={setQuery}
-      placeholder={getLabels().search.enterWord}
+      placeholder={placeholder}
       rightContainer={<MagnifierIcon width={theme.spacingsPlain.md} height={theme.spacingsPlain.md} />}
     />
   )

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -3,7 +3,8 @@
     "welcome": "Willkommen bei Lunes!",
     "selectProfession": "Wähle deinen Beruf!",
     "skipSelection": "Überspringen",
-    "confirmSelection": "Starten"
+    "confirmSelection": "Starten",
+    "searchProfession": "Suche Beruf"
   },
   "home": {
     "welcome": "Willkommen bei Lunes!",

--- a/src/hooks/useLoadDisciplines.ts
+++ b/src/hooks/useLoadDisciplines.ts
@@ -9,11 +9,15 @@ export type RequestParams =
     }
   | {
       parent: Discipline | null
+      allLevels?: boolean
     }
 
 const getEndpoint = (params: RequestParams): string => {
   if (isTypeLoadProtected(params)) {
     return ENDPOINTS.groupInfo
+  }
+  if (params.allLevels) {
+    return `${ENDPOINTS.discipline}/`
   }
   if (params.parent?.needsTrainingSetEndpoint) {
     return `${ENDPOINTS.trainingSet}/${params.parent.id}`

--- a/src/routes/scope-selection/__tests__/ScopeSelectionScreen.spec.tsx
+++ b/src/routes/scope-selection/__tests__/ScopeSelectionScreen.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, waitFor } from '@testing-library/react-native'
 import { mocked } from 'jest-mock'
 import React from 'react'
 
+import { Discipline } from '../../../constants/endpoints'
 import { useLoadDisciplines } from '../../../hooks/useLoadDisciplines'
 import useReadSelectedProfessions from '../../../hooks/useReadSelectedProfessions'
 import { RoutesParams } from '../../../navigation/NavigationTypes'
@@ -11,7 +12,7 @@ import createNavigationMock from '../../../testing/createNavigationPropMock'
 import { getReturnOf } from '../../../testing/helper'
 import { mockDisciplines } from '../../../testing/mockDiscipline'
 import render from '../../../testing/render'
-import ScopeSelection from '../ScopeSelectionScreen'
+import ScopeSelection, { searchProfessions } from '../ScopeSelectionScreen'
 
 jest.mock('@react-navigation/native')
 jest.mock('../../../hooks/useLoadDisciplines')
@@ -30,6 +31,7 @@ describe('ScopeSelection', () => {
   it('should navigate to profession selection', () => {
     mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     mocked(useReadSelectedProfessions).mockReturnValueOnce(getReturnOf(null))
+    mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
 
     const { getByText } = render(<ScopeSelection navigation={navigation} route={getRoute()} />)
     expect(getByText(getLabels().scopeSelection.welcome)).toBeDefined()
@@ -49,6 +51,7 @@ describe('ScopeSelection', () => {
   it('should skip selection', async () => {
     mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     mocked(useReadSelectedProfessions).mockReturnValueOnce(getReturnOf(null))
+    mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     const { getByText } = render(<ScopeSelection navigation={navigation} route={getRoute()} />)
     const button = getByText(getLabels().scopeSelection.skipSelection)
     fireEvent.press(button)
@@ -64,6 +67,7 @@ describe('ScopeSelection', () => {
   it('should confirm selection', () => {
     mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     mocked(useReadSelectedProfessions).mockReturnValueOnce(getReturnOf([mockDisciplines()[0].id]))
+    mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     const { getByText } = render(<ScopeSelection navigation={navigation} route={getRoute()} />)
     const button = getByText(getLabels().scopeSelection.confirmSelection)
     fireEvent.press(button)
@@ -77,9 +81,25 @@ describe('ScopeSelection', () => {
   it('should hide welcome message and buttons for non initial view', () => {
     mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     mocked(useReadSelectedProfessions).mockReturnValueOnce(getReturnOf([mockDisciplines()[0].id]))
+    mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
     const { queryByText } = render(<ScopeSelection navigation={navigation} route={getRoute(false)} />)
     expect(queryByText(getLabels().scopeSelection.welcome)).toBeNull()
     expect(queryByText(getLabels().scopeSelection.skipSelection)).toBeNull()
     expect(queryByText(getLabels().scopeSelection.confirmSelection)).toBeNull()
+  })
+
+  describe('searchProfessions', () => {
+    it('should find a profession', () => {
+      const professions: Discipline[] = mockDisciplines()
+      expect(searchProfessions(professions, 'disc')).toStrictEqual(professions)
+      expect(searchProfessions(professions, 'SECOND')).toStrictEqual([professions[1]])
+      expect(searchProfessions(professions, 'd discipline')).toStrictEqual([professions[1], professions[2]])
+    })
+
+    it('should not find a profession', () => {
+      const professions: Discipline[] = mockDisciplines()
+      expect(searchProfessions(professions, 'fourth discipline')).toStrictEqual([])
+      expect(searchProfessions(professions, 'Maler')).toStrictEqual([])
+    })
   })
 })

--- a/src/services/__tests__/helpers.spec.ts
+++ b/src/services/__tests__/helpers.spec.ts
@@ -15,6 +15,7 @@ import {
   getNextExercise,
   getProgress,
   getSortedAndFilteredVocabularyItems,
+  splitTextBySearchString,
   willNextExerciseUnlock,
 } from '../helpers'
 
@@ -189,6 +190,7 @@ describe('helpers', () => {
       expect(resultForA).toHaveLength(6)
       expect(resultForU).toHaveLength(4)
     })
+
     it('should check alternative words with ö,ä,ü whether they are found correctly when searching for both ö,ü,a and o,u,a', () => {
       const resultForOe = getSortedAndFilteredVocabularyItems(testData, 'ölkännchen')
       const resultForAe = getSortedAndFilteredVocabularyItems(testData, 'abhänger')
@@ -321,6 +323,39 @@ describe('helpers', () => {
       ]
       const sortedTestData = getSortedAndFilteredVocabularyItems(testData, '')
       expect(sortedData).toEqual(sortedTestData)
+    })
+  })
+
+  describe('splitTextBySearchString', () => {
+    const allText = 'Hello World'
+    it('should not find a search string', () => {
+      const highlight = 'Goodbye'
+      expect(splitTextBySearchString(allText, highlight)).toStrictEqual([allText])
+    })
+
+    it('should find a search string at the start', () => {
+      const highlight = 'Hel'
+      expect(splitTextBySearchString(allText, highlight)).toStrictEqual(['', 'Hel', 'lo World'])
+    })
+
+    it('should find a search string at the end', () => {
+      const highlight = 'World'
+      expect(splitTextBySearchString(allText, highlight)).toStrictEqual(['Hello ', 'World', ''])
+    })
+
+    it('should find a search string in the middle', () => {
+      const highlight = 'lo '
+      expect(splitTextBySearchString(allText, highlight)).toStrictEqual(['Hel', 'lo ', 'World'])
+    })
+
+    it('should ignore casing', () => {
+      const highlight = 'wor'
+      expect(splitTextBySearchString(allText, highlight)).toStrictEqual(['Hello ', 'Wor', 'ld'])
+    })
+
+    it('should find a search string with umlauts', () => {
+      const highlight = 'Wörld'
+      expect(splitTextBySearchString(allText, highlight)).toStrictEqual(['Hello ', 'World', ''])
     })
   })
 })

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -169,7 +169,7 @@ export const calculateScore = (vocabularyItemsWithResults: VocabularyItemResult[
     vocabularyItemsWithResults
       .filter(doc => doc.result === 'correct')
       .reduce((acc, vocabularyItemResult) => {
-        let score = acc
+        let score: number = acc
         switch (vocabularyItemResult.numberOfTries) {
           case 1:
             score += SCORE_FIRST_TRY
@@ -228,3 +228,16 @@ export const willNextExerciseUnlock = (previousScore: number | undefined, score:
 export const millisecondsToDays = (milliseconds: number): number => milliseconds / (24 * 60 * 60 * 1000)
 /* eslint-disable-next-line no-magic-numbers */
 export const milliSecondsToHours = (milliseconds: number): number => milliseconds / (60 * 60 * 1000)
+
+export const splitTextBySearchString = (allText: string, highlight: string): [string] | [string, string, string] => {
+  const highlightIndex = normalizeStrings(allText.toLowerCase()).indexOf(normalizeStrings(highlight.toLowerCase()))
+  if (highlightIndex === -1) {
+    return [allText]
+  }
+  const indexAfterHighlight = highlightIndex + highlight.length
+  return [
+    allText.slice(0, highlightIndex),
+    allText.slice(highlightIndex, indexAfterHighlight),
+    allText.slice(indexAfterHighlight),
+  ]
+}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Adding a search function to the screen for selecting a profession.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Added new reference to the endpoint to get all professions
- Added a search bar and a function to filter through all those professions (I decided against a fancier search function because we currently have 33 professions and so it feels like a premature optimization)
- Added the results, including a function to highlight the search string in the title

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I added a placeholder parameter to the SearchBar.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #921 

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
