### PR TITLE
1017: Upgrade xcode 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
             FL_OUTPUT_DIR: output
             TOTAL_CPUS: 4
         macos:
-            xcode: 14.2.0
+            xcode: 15.2.0
         resource_class: macos.m1.medium.gen1
         shell: /bin/bash --login -o pipefail
         steps:
@@ -427,7 +427,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 14.2.0
+            xcode: 15.2.0
         parameters:
             production_delivery:
                 default: false
@@ -553,7 +553,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 14.2.0
+            xcode: 15.2.0
         shell: /bin/bash --login -o pipefail
         steps:
             - checkout

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,5 +1,5 @@
 macos:
-  xcode: 14.2.0
+  xcode: 15.2.0
 resource_class: macos.m1.medium.gen1
 environment:
   FL_OUTPUT_DIR: output

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -6,7 +6,7 @@ parameters:
     type: boolean
     default: false
 macos:
-  xcode: 14.2.0
+  xcode: 15.2.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash --login -o pipefail

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -1,6 +1,6 @@
 # Promotes the app from Testflight to the Apple App Store.
 macos:
-  xcode: 14.2.0
+  xcode: 15.2.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash --login -o pipefail

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -79,6 +79,8 @@ target 'Lunes' do
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
         config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = "arm64"
+        # https://github.com/facebook/react-native/issues/37748 will be fixed with RN 0.72.5
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
       end
     end
     # Signing on XCode 14 builds


### PR DESCRIPTION
### Short description

Since we won't be able to publish ios apps after 29th of April, with XCode 14, we have to upgrade to xcode 15

### Proposed changes

<!-- Describe this PR in more detail. -->

- upgrade to xcode15

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1017

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
