### PR TITLE
1009: Upgrade android images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ commands:
 jobs:
     build_android:
         docker:
-            - image: cimg/android:2022.08.1-node
+            - image: cimg/android:2024.01.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
             TOTAL_CPUS: 3
@@ -355,7 +355,7 @@ jobs:
             - notify
     deliver_android:
         docker:
-            - image: cimg/android:2022.08.1-node
+            - image: cimg/android:2024.01.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         parameters:
@@ -391,7 +391,7 @@ jobs:
             - notify
     deliver_browser_stack:
         docker:
-            - image: cimg/android:2022.08.1-node
+            - image: cimg/android:2024.01.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         shell: /bin/bash -eo pipefail
@@ -535,7 +535,7 @@ jobs:
                 success_message: <<^ parameters.production_delivery >>[Development] <</ parameters.production_delivery >>Lunes ${NEW_VERSION_NAME} has been released successfully on iOS!\n${RELEASE_NOTES}\n${IOS_ARTIFACT_URLS}
     promote_android:
         docker:
-            - image: cimg/android:2022.08.1-node
+            - image: cimg/android:2024.01.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         resource_class: small

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/android:2022.08.1-node
+  - image: cimg/android:2024.01.1-node
 resource_class: medium+
 environment:
   TOTAL_CPUS: 3

--- a/.circleci/src/jobs/deliver_android.yml
+++ b/.circleci/src/jobs/deliver_android.yml
@@ -3,7 +3,7 @@ parameters:
     description: Whether to deliver the build to production.
     type: boolean
 docker:
-  - image: cimg/android:2022.08.1-node
+  - image: cimg/android:2024.01.1-node
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash -eo pipefail

--- a/.circleci/src/jobs/deliver_browser_stack.yml
+++ b/.circleci/src/jobs/deliver_browser_stack.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/android:2022.08.1-node
+  - image: cimg/android:2024.01.1-node
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash -eo pipefail

--- a/.circleci/src/jobs/promote_android.yml
+++ b/.circleci/src/jobs/promote_android.yml
@@ -1,6 +1,6 @@
 # Promote the app from the beta to the production track in the Google Play Store.
 docker:
-  - image: cimg/android:2022.08.1-node
+  - image: cimg/android:2024.01.1-node
 resource_class: small
 shell: /bin/bash -eo pipefail
 environment:


### PR DESCRIPTION
### Short description

Since android images get EOL in september, we have to upgrade them

### Proposed changes

<!-- Describe this PR in more detail. -->

- upgrade to cimg/android:2024.01.1-node


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1009

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
