### PR TITLE
Remove Sarah and Max from Notifications and codeowners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
                 default: lunes-app
                 type: string
             failure_mentions:
-                default: '@max.ammann @stefanie.metzger @sarah.sporck @steffen.kleinle @andreas.fischer'
+                default: '@stefanie.metzger @steffen.kleinle @andreas.fischer @leandra.hahn'
                 type: string
             only_for_branch:
                 default: main

--- a/.circleci/src/commands/notify.yml
+++ b/.circleci/src/commands/notify.yml
@@ -4,7 +4,7 @@ parameters:
     default: ''
     type: string
   failure_mentions:
-    default: '@max.ammann @stefanie.metzger @sarah.sporck @steffen.kleinle @andreas.fischer'
+    default: '@stefanie.metzger @steffen.kleinle @andreas.fischer @leandra.hahn'
     type: string
   success_mentions:
     default: ''

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for
 # review when someone opens a pull request.
-*       @steffenkleinle @ztefanie @sarahsporck @f1sh1918 @LeandraH
+*       @steffenkleinle @ztefanie @f1sh1918 @LeandraH


### PR DESCRIPTION
### Short description
Adjusted team members
