### PR TITLE
1009: Fix ruby gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ commands:
                     - 3-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
                     - 3-gems-{{ arch }}-
             - run:
-                command: bundle check || bundle install
+                command: bundle check || sudo bundle install
                 name: Install Fastlane
                 working_directory: << parameters.directory >>
             - save_cache:

--- a/.circleci/src/commands/restore_ruby_cache.yml
+++ b/.circleci/src/commands/restore_ruby_cache.yml
@@ -10,7 +10,7 @@ steps:
         - 3-gems-{{ arch }}-
   - run:
       name: Install Fastlane
-      command: bundle check || bundle install
+      command: bundle check || sudo bundle install
       working_directory: << parameters.directory >>
   - save_cache:
       key: 3-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}


### PR DESCRIPTION
### Short description

With the new android images it seems like the permissions to folders changed and there are issues with ruby gems.

### Proposed changes

<!-- Describe this PR in more detail. -->

- added `sudo` to bundle install

Here you can check that android builds successfully
https://app.circleci.com/pipelines/github/digitalfabrik/lunes-app/3514/workflows/7a8e9e73-13c7-4e38-9924-5e50ebb27beb/jobs/11718

ios failed due to  #1017  wasn't merged

### Additional Information
https://github.com/rubygems/rubygems/issues/6290
