### PR TITLE
1023: Rename article field in API response

### DIFF
--- a/release-notes/unreleased/1023-rename-article-field.yml
+++ b/release-notes/unreleased/1023-rename-article-field.yml
@@ -1,0 +1,6 @@
+issue_key: 1023
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Die App crasht nicht mehr, wenn man die Vokabelliste öffnet

--- a/src/hooks/__tests__/useLoadVocabularyItems.spec.ts
+++ b/src/hooks/__tests__/useLoadVocabularyItems.spec.ts
@@ -12,18 +12,18 @@ const testData = [
     alternatives: [
       {
         alt_word: 'Meterstab',
-        article: 1,
+        singular_article: 1,
       },
       {
         alt_word: 'Gliedermaßstab',
-        article: 1,
+        singular_article: 1,
       },
       {
         alt_word: 'Zoll-Stock',
-        article: 1,
+        singular_article: 1,
       },
     ],
-    article: 1,
+    singular_article: 1,
     audio: 'https://lunes-test.tuerantuer.org/media/audio/c966db1e-250e-11ec-991f-960000c17cb9.mp3',
     document_image: [],
     id: 17,
@@ -32,7 +32,7 @@ const testData = [
   },
   {
     alternatives: [],
-    article: 1,
+    singular_article: 1,
     audio: 'https://lunes-test.tuerantuer.org/media/audio/Oelkanister-conv.mp3',
     document_image: [],
     id: 178,
@@ -41,7 +41,7 @@ const testData = [
   },
   {
     alternatives: [],
-    article: 2,
+    singular_article: 2,
     audio: 'https://lunes-test.tuerantuer.org/media/audio/Oelkreide-conv.mp3',
     document_image: [],
     id: 245,

--- a/src/hooks/useLoadVocabularyItems.ts
+++ b/src/hooks/useLoadVocabularyItems.ts
@@ -4,14 +4,14 @@ import { getFromEndpoint } from '../services/axios'
 import useLoadAsync, { Return } from './useLoadAsync'
 
 export type AlternativeWordFromServer = {
-  article: number
+  singular_article: number
   alt_word: string
 }
 
 export type VocabularyItemFromServer = {
   id: number
   word: string
-  article: number
+  singular_article: number
   document_image: Array<{ id: number; image: string }>
   audio: string
   alternatives: AlternativeWordFromServer[]
@@ -25,10 +25,10 @@ export const formatVocabularyItemFromServer = (
   word: vocabularyItemFromServer.word,
   audio: vocabularyItemFromServer.audio,
   type: apiKey ? VOCABULARY_ITEM_TYPES.lunesProtected : VOCABULARY_ITEM_TYPES.lunesStandard,
-  article: ARTICLES[vocabularyItemFromServer.article],
+  article: ARTICLES[vocabularyItemFromServer.singular_article],
   images: vocabularyItemFromServer.document_image,
   alternatives: vocabularyItemFromServer.alternatives.map(it => ({
-    article: ARTICLES[it.article],
+    article: ARTICLES[it.singular_article],
     word: it.alt_word,
   })),
   apiKey,


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
The app started crashing when opening the vocabulary list because the field `article` had been renamed to `singular_article` in the CMS. This renames that field also in the response parser.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Renamed `article` to `singular_article` in `useLoadVocabularyItems`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The app should not crash anymore when opening the vocabulary list.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1023 

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
