### PR TITLE
1046: Close sidebar menu on navigation back

### DIFF
--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -7,6 +7,7 @@ import ImprintScreen from '../routes/ImprintScreen'
 import AddCustomDisciplineScreen from '../routes/add-custom-discipline/AddCustomDisciplineScreen'
 import StandardExercisesScreen from '../routes/exercises/StandardExercisesScreen'
 import HomeScreen from '../routes/home/HomeScreen'
+import ManageSelectionsScreen from '../routes/manage-selections/ManageSelectionsScreen'
 import SettingsScreen from '../routes/settings/SettingsScreen'
 import SponsorsScreen from '../routes/sponsors/SponsorsScreen'
 import { getLabels } from '../services/helpers'
@@ -17,7 +18,7 @@ const Stack = createStackNavigator<RoutesParams>()
 
 const HomeStackNavigator = (): JSX.Element | null => {
   const options = screenOptions(useTabletHeaderHeight())
-  const { overview } = getLabels().general.header
+  const { manageSelection, overview } = getLabels().general.header
   const theme = useTheme()
 
   return (
@@ -27,6 +28,11 @@ const HomeStackNavigator = (): JSX.Element | null => {
         name='DisciplineSelection'
         component={DisciplineSelectionScreen}
         options={({ navigation }) => options(overview, navigation)}
+      />
+      <Stack.Screen
+        name='ManageSelection'
+        component={ManageSelectionsScreen}
+        options={({ navigation }) => options(manageSelection, navigation)}
       />
       <Stack.Screen
         name='StandardExercises'

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -10,7 +10,6 @@ import VocabularyListScreen from '../routes/VocabularyListScreen'
 import ArticleChoiceExerciseScreen from '../routes/choice-exercises/ArticleChoiceExerciseScreen'
 import WordChoiceExerciseScreen from '../routes/choice-exercises/WordChoiceExerciseScreen'
 import ExerciseFinishedScreen from '../routes/exercise-finished/ExerciseFinishedScreen'
-import ManageSelectionsScreen from '../routes/manage-selections/ManageSelectionsScreen'
 import ScopeSelection from '../routes/scope-selection/ScopeSelectionScreen'
 import VocabularyDetailExerciseScreen from '../routes/vocabulary-detail-exercise/VocabularyDetailExerciseScreen'
 import WriteExerciseScreen from '../routes/write-exercise/WriteExerciseScreen'
@@ -40,11 +39,6 @@ const HomeStackNavigator = (): JSX.Element | null => {
         name='ScopeSelection'
         component={ScopeSelection}
         initialParams={{ initialSelection: true }}
-        options={({ navigation }) => options(manageSelection, navigation)}
-      />
-      <Stack.Screen
-        name='ManageSelection'
-        component={ManageSelectionsScreen}
         options={({ navigation }) => options(manageSelection, navigation)}
       />
       <Stack.Screen


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where the sidebar stayed open when clicking on "Lernbereiche verwalten" and then going back.

Should I include a release not for this small bugfix?

### Proposed changes

<!-- Describe this PR in more detail. -->
- Move the `ManageSelectionScreen` from the root navigator to the `HomeStackNavigator`, so that react pops the menu, instead of putting the screen on top of it

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Hopefully none :D

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1046

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
