### PR TITLE
1051: Fix loss of precision error in vocabulary list

### DIFF
--- a/src/components/ExerciseHeader.tsx
+++ b/src/components/ExerciseHeader.tsx
@@ -133,7 +133,7 @@ const ExerciseHeader = ({
     <>
       {showProgress && (
         <ProgressBar
-          progress={numberOfWords > 0 ? currentWord / numberOfWords : 0}
+          animatedValue={numberOfWords > 0 ? currentWord / numberOfWords : 0}
           color={theme.colors.progressIndicator}
           disabledColor={theme.colors.disabled}
         />


### PR DESCRIPTION
### Short description

After upgrading react native to v0.74, the react-native-paper was also updated which resulted in the `loss precision error`. The `progress` prop of` ProgressBar `component caused this issue. The workaround is mentioned [here](https://github.com/facebook/react-native/issues/47635#issuecomment-2507431266)

### Proposed changes

<!-- Describe this PR in more detail. -->

- Change the `progress` prop to `animatedValue`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none :)

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1051 

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
