### PR TITLE
1042: Add text to long term excercise

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -59,6 +59,7 @@ type ButtonProps = {
   iconRight?: ComponentType<SvgProps>
   style?: StyleProp<ViewStyle>
   iconSize?: number
+  testID?: string
 }
 
 const Button = (props: ButtonProps): ReactElement => {
@@ -71,6 +72,7 @@ const Button = (props: ButtonProps): ReactElement => {
     buttonTheme = BUTTONS_THEME.outlined,
     style,
     iconSize = theme.spacingsPlain.md,
+    testID = 'button',
   } = props
 
   const getTextColor = (): Color => {
@@ -97,7 +99,7 @@ const Button = (props: ButtonProps): ReactElement => {
   return (
     <ThemedButton
       buttonTheme={buttonTheme}
-      testID='button'
+      testID={testID}
       isPressed={isPressed}
       backgroundColor={getBackgroundColor()}
       onPress={onPress}

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -192,6 +192,7 @@
     "yourLearningProgress": "Dein Lernfortschritt",
     "hintModalHeaderText": "Du kannst gelernte Wörter jetzt wiederholen",
     "hintModalContentText": "Unter dem Kapitel „Wiederholen“ kannst du nun dein Langzeitgedächtnis trainieren.",
+    "infoModalContentText": "Die Wiederholungsübung hilft dir, Vokabeln nachhaltig zu lernen, indem es Wiederholungen optimal an deinen Wissensstand anpasst. Jede Karte durchläuft 7 Phasen: Anfangs wiederholst du häufiger, später in größeren Abständen. So speicherst du Wissen langfristig im Gedächtnis!",
     "repeatLater": "später",
     "chart": {
       "untrained": "Neue",

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -188,7 +188,10 @@
   "repetition": {
     "repeatWords": "Wörter wiederholen",
     "repeatNow": "Jetzt wiederholen",
-    "wordsToRepeat": "Wörter zum Wiederholen bereit",
+    "wordsToRepeat": {
+      "singular": "Wort zum Wiederholen bereit",
+      "plural": "Wörter zum Wiederholen bereit"
+    },
     "yourLearningProgress": "Dein Lernfortschritt",
     "hintModalHeaderText": "Du kannst gelernte Wörter jetzt wiederholen",
     "hintModalContentText": "Unter dem Kapitel „Wiederholen“ kannst du nun dein Langzeitgedächtnis trainieren.",

--- a/src/routes/repetition/RepetitionScreen.tsx
+++ b/src/routes/repetition/RepetitionScreen.tsx
@@ -8,15 +8,15 @@ import { InfoCircleBlackIcon } from '../../../assets/images'
 import Button from '../../components/Button'
 import ModalSkeleton from '../../components/ModalSkeleton'
 import RouteWrapper from '../../components/RouteWrapper'
+import { ContentSecondary } from '../../components/text/Content'
 import { HeadingText } from '../../components/text/Heading'
 import { BUTTONS_THEME } from '../../constants/data'
 import theme from '../../constants/theme'
 import useLoadAsync from '../../hooks/useLoadAsync'
 import { RoutesParams } from '../../navigation/NavigationTypes'
 import { RepetitionService } from '../../services/RepetitionService'
-import { getLabels } from '../../services/helpers'
+import { getLabels, pluralize } from '../../services/helpers'
 import RepetitionProgressChart from './components/RepetitionProgressChart'
-import { ContentSecondary } from '../../components/text/Content'
 
 const Root = styled.ScrollView`
   padding: 0 ${props => props.theme.spacings.sm};
@@ -100,7 +100,7 @@ const RepetitionScreen = ({ navigation }: RepetitionScreenProps): ReactElement =
       <Root>
         <StyledHeading>{repeatWords}</StyledHeading>
         <Container>
-          <TextContainer>{`${numberOfWordsNeedingRepetition ?? 0} ${wordsToRepeat}`}</TextContainer>
+          <TextContainer>{`${numberOfWordsNeedingRepetition ?? 0} ${pluralize(wordsToRepeat, numberOfWordsNeedingRepetition)}`}</TextContainer>
           <Button onPress={navigate} label={repeatNow} buttonTheme={BUTTONS_THEME.contained} />
         </Container>
         <Container>

--- a/src/routes/repetition/RepetitionScreen.tsx
+++ b/src/routes/repetition/RepetitionScreen.tsx
@@ -101,7 +101,13 @@ const RepetitionScreen = ({ navigation }: RepetitionScreenProps): ReactElement =
         <StyledHeading>{repeatWords}</StyledHeading>
         <Container>
           <TextContainer>{`${numberOfWordsNeedingRepetition ?? 0} ${pluralize(wordsToRepeat, numberOfWordsNeedingRepetition)}`}</TextContainer>
-          <Button onPress={navigate} label={repeatNow} buttonTheme={BUTTONS_THEME.contained} />
+          <Button
+            testID='repetition-button'
+            onPress={navigate}
+            label={repeatNow}
+            buttonTheme={BUTTONS_THEME.contained}
+            disabled={(numberOfWordsNeedingRepetition ?? 0) === 0}
+          />
         </Container>
         <Container>
           <HeaderWrapper>

--- a/src/routes/repetition/RepetitionScreen.tsx
+++ b/src/routes/repetition/RepetitionScreen.tsx
@@ -16,6 +16,7 @@ import { RoutesParams } from '../../navigation/NavigationTypes'
 import { RepetitionService } from '../../services/RepetitionService'
 import { getLabels } from '../../services/helpers'
 import RepetitionProgressChart from './components/RepetitionProgressChart'
+import { ContentSecondary } from '../../components/text/Content'
 
 const Root = styled.ScrollView`
   padding: 0 ${props => props.theme.spacings.sm};
@@ -64,13 +65,16 @@ const ModalContainer = styled.View`
   align-items: center;
   height: ${hp('24%')}px;
 `
+const ModalContent = styled(ContentSecondary)`
+  padding: ${props => props.theme.spacings.xs};
+`
 
 type RepetitionScreenProps = {
   navigation: StackNavigationProp<RoutesParams, 'Repetition'>
 }
 const RepetitionScreen = ({ navigation }: RepetitionScreenProps): ReactElement => {
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
-  const { repeatWords, repeatNow, wordsToRepeat, yourLearningProgress } = getLabels().repetition
+  const { repeatWords, repeatNow, wordsToRepeat, yourLearningProgress, infoModalContentText } = getLabels().repetition
   const { data: numberOfWordsNeedingRepetition, refresh: refreshNumberOfWordsNeedingRepetition } = useLoadAsync(
     RepetitionService.getNumberOfWordsNeedingRepetitionWithUpperBound,
     undefined,
@@ -114,7 +118,9 @@ const RepetitionScreen = ({ navigation }: RepetitionScreenProps): ReactElement =
           <RepetitionProgressChart />
         </Container>
         <ModalSkeleton visible={isModalVisible} onClose={() => setIsModalVisible(false)} testID='infoModal'>
-          <ModalContainer />
+          <ModalContainer>
+            <ModalContent>{infoModalContentText}</ModalContent>
+          </ModalContainer>
         </ModalSkeleton>
       </Root>
     </RouteWrapper>

--- a/src/routes/repetition/__tests__/RepetitionScreen.spec.tsx
+++ b/src/routes/repetition/__tests__/RepetitionScreen.spec.tsx
@@ -20,7 +20,7 @@ describe('RepetitionScreen', () => {
       Promise.resolve(2),
     )
     const { getByText, getByTestId } = render(<RepetitionScreen navigation={navigation} />)
-    await waitFor(() => expect(getByText(`2 ${getLabels().repetition.wordsToRepeat}`)).toBeDefined())
+    await waitFor(() => expect(getByText(`2 ${getLabels().repetition.wordsToRepeat.plural}`)).toBeDefined())
     expect(getByTestId('info-circle-black-icon')).toBeDefined()
     expect(getByText(getLabels().repetition.repeatNow)).toBeDefined()
   })

--- a/src/routes/repetition/__tests__/RepetitionScreen.spec.tsx
+++ b/src/routes/repetition/__tests__/RepetitionScreen.spec.tsx
@@ -21,8 +21,20 @@ describe('RepetitionScreen', () => {
     )
     const { getByText, getByTestId } = render(<RepetitionScreen navigation={navigation} />)
     await waitFor(() => expect(getByText(`2 ${getLabels().repetition.wordsToRepeat.plural}`)).toBeDefined())
+    await waitFor(() => expect(getByTestId('repetition-button')).toBeEnabled())
     expect(getByTestId('info-circle-black-icon')).toBeDefined()
     expect(getByText(getLabels().repetition.repeatNow)).toBeDefined()
+  })
+
+  it('should disable button correctly', async () => {
+    mocked(RepetitionService.getNumberOfWordsNeedingRepetitionWithUpperBound).mockImplementation(() =>
+      Promise.resolve(0),
+    )
+
+    const { getByTestId } = render(<RepetitionScreen navigation={navigation} />)
+    await waitFor(() => {
+      expect(getByTestId('repetition-button')).toBeDisabled()
+    })
   })
 
   it('should open modal on icon click', async () => {

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -154,6 +154,13 @@ export const loadTrainingsSet = async (disciplineId: number): Promise<ServerResp
 
 export const getLabels = (): typeof labels => labels
 
+export const pluralize = (labels: { singular: string; plural: string }, n: number | null): string => {
+  if (n === 1) {
+    return labels.singular
+  }
+  return labels.plural
+}
+
 export const sendFeedback = (comment: string, feedbackType: FeedbackType, id: number): Promise<AxiosResponse> =>
   postToEndpoint(ENDPOINTS.feedback, {
     comment,


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This pr addresses #1042 , which solves two problems:

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add a text to the long term repetition info modal
- Fix the pluralization of the `wordsToRepeat` label
- (Not part of the original issue) Disable the repetition button if there are no words to repeat

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

should be none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1042 

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
