### PR TITLE
Hide the repetition badge number if it is zero

### DIFF
--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -107,7 +107,10 @@ const BottomTabNavigator = (): JSX.Element | null => {
           component={RepetitionStackNavigator}
           options={{
             tabBarIcon: renderRepetitionTabIcon,
-            tabBarBadge: numberOfWordsNeedingRepetition ?? undefined,
+            tabBarBadge:
+              numberOfWordsNeedingRepetition !== null && numberOfWordsNeedingRepetition > 0
+                ? numberOfWordsNeedingRepetition
+                : undefined,
             title: getLabels().general.repetition,
           }}
         />


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This pr hides the repetition badge number if it is zero. This fixes the non-duplicate part of issue #995.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Hide number if zero

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #995

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
