### PR TITLE
917: Add edit button to vocabulary detail screen

### DIFF
--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'styled-components'
 
 import { useTabletHeaderHeight } from '../hooks/useTabletHeaderHeight'
 import UserVocabularyOverviewScreen from '../routes/UserVocabularyOverviewScreen'
-import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
+import { EditableVocabularyDetailsScreen } from '../routes/VocabularyDetailScreen'
 import UserVocabularyProcessScreen from '../routes/process-user-vocabulary/UserVocabularyProcessScreen'
 import SpecialExercisesScreen from '../routes/special-exercises/SpecialExercisesScreen'
 import UserVocabularyDisciplineSelectionScreen from '../routes/user-vocabulary-discipline-selection/UserVocabularyDisciplineSelectionScreen'
@@ -36,7 +36,7 @@ const UserVocabularyStackNavigator = (): JSX.Element | null => {
       />
       <Stack.Screen
         name='VocabularyDetail'
-        component={VocabularyDetailScreen}
+        component={EditableVocabularyDetailsScreen}
         options={({ navigation }) => options(back, navigation)}
       />
       <Stack.Screen

--- a/src/routes/VocabularyDetailScreen.tsx
+++ b/src/routes/VocabularyDetailScreen.tsx
@@ -1,21 +1,69 @@
-import { RouteProp } from '@react-navigation/native'
-import React, { ReactElement } from 'react'
+import { RouteProp, useFocusEffect } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import React, { ReactElement, useCallback } from 'react'
 
+import { PenIcon } from '../../assets/images'
+import PressableOpacity from '../components/PressableOpacity'
 import RouteWrapper from '../components/RouteWrapper'
 import VocabularyDetail from '../components/VocabularyDetail'
+import { VOCABULARY_ITEM_TYPES } from '../constants/data'
+import { VocabularyItem } from '../constants/endpoints'
 import { RoutesParams } from '../navigation/NavigationTypes'
+import { getLabels } from '../services/helpers'
 
 type VocabularyDetailScreenProps = {
   route: RouteProp<RoutesParams, 'VocabularyDetail'>
 }
 
-const VocabularyDetailScreen = ({ route }: VocabularyDetailScreenProps): ReactElement => {
+type EditableVocabularyDetailScreenProps = {
+  route: RouteProp<RoutesParams, 'VocabularyDetail'>
+  navigation: StackNavigationProp<RoutesParams, 'VocabularyDetail'>
+}
+
+type EditButtonProps = {
+  navigation: StackNavigationProp<RoutesParams, 'VocabularyDetail'>
+  vocabularyItem: VocabularyItem
+}
+
+const EditButton = ({ navigation, vocabularyItem }: EditButtonProps) => (
+  <PressableOpacity
+    onPress={() =>
+      navigation.navigate('UserVocabularyProcess', {
+        headerBackLabel: getLabels().general.back,
+        itemToEdit: vocabularyItem,
+      })
+    }>
+    <PenIcon />
+  </PressableOpacity>
+)
+
+const VocabularyDetailScreen = ({ route }: VocabularyDetailScreenProps): ReactElement | null => {
   const { vocabularyItem } = route.params
+
   return (
     <RouteWrapper>
       <VocabularyDetail vocabularyItem={vocabularyItem} />
     </RouteWrapper>
   )
+}
+
+export const EditableVocabularyDetailsScreen = ({
+  route,
+  navigation,
+}: EditableVocabularyDetailScreenProps): ReactElement | null => {
+  const { vocabularyItem } = route.params
+
+  useFocusEffect(
+    useCallback(() => {
+      if (vocabularyItem.type === VOCABULARY_ITEM_TYPES.userCreated) {
+        navigation.setOptions({
+          headerRight: () => EditButton({ navigation, vocabularyItem }),
+        })
+      }
+    }, [vocabularyItem, navigation]),
+  )
+
+  return <VocabularyDetailScreen route={route} />
 }
 
 export default VocabularyDetailScreen


### PR DESCRIPTION
### Short description

Adds a button to the vocabulary details screen that navigates to the vocabulary process screen.
This button will only be visible in the "my words" tab, but not in the vocabulary details screens from the favorites tab or the search tab.


<!-- Describe this PR in one or two sentences. -->

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add `EditableVocabularyDetailsScreen` component
- If editable, show a button to navigation to the process screen in the navigation bar

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #917 

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
