### PR TITLE
Fix bottom tab texts being cut off

### DIFF
--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -135,7 +135,7 @@
     "home": "Start",
     "favorites": "Favoriten",
     "dictionary": "Suche",
-    "repetition": "Wiederholen",
+    "repetition": "Vertiefen",
     "userVocabulary": "Meine Vokabeln",
     "header": {
       "overview": "Übersicht",
@@ -225,7 +225,7 @@
     "sponsorsExplanation": "Unsere Unterstützer*innen helfen uns mit Vokabel- oder Bildspenden, Inhaltsüberprüfung und/oder finanzieller Hilfe"
   },
   "userVocabulary": {
-    "myWords": "Meine Wörter",
+    "myWords": "Sammlung",
     "create": "Eigenes Wort erstellen",
     "overview": {
       "list": "Vokabelliste",


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This pr fixes the ellipsis that is shown in the bottom tab navigator on devices with small screens.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Rename "Wiederholen" to "Vertiefen"
- Rename "Meine Wörter" to "Sammlung"
  * This is still cut off on a small iphone

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1041

---
<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
