### PR TITLE
Remove android `READ_MEDIA_IMAGES` permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
It should not be required anymore, because android now has the media picker. This pr will ideally fix the release.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Remove the permission from android manifest

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Ideally none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
