### PR TITLE
IOS: Fix value for `UIRequiredDeviceCapabilities`

### DIFF
--- a/ios/Lunes/Info.plist
+++ b/ios/Lunes/Info.plist
@@ -86,7 +86,7 @@
     <string>LaunchScreen</string>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
-        <string>armv64</string>
+        <string>arm64</string>
     </array>
     <key>UIStatusBarStyle</key>
     <string>UIStatusBarStyleLightContent</string>


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
According to the documentation, `armv64` is not an allowed value here: https://developer.apple.com/documentation/bundleresources/information-property-list/uirequireddevicecapabilities This also matches the value we have in the integreat app

### Proposed changes

<!-- Describe this PR in more detail. -->

- Change to value to `arm64`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- maybe app upload works now? :)

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
