### PR TITLE
Fix wrong labels in user vocabulary

### DIFF
--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -225,7 +225,7 @@
     "sponsorsExplanation": "Unsere Unterstützer*innen helfen uns mit Vokabel- oder Bildspenden, Inhaltsüberprüfung und/oder finanzieller Hilfe"
   },
   "userVocabulary": {
-    "myWords": "Sammlung",
+    "collection": "Sammlung",
     "create": "Eigenes Wort erstellen",
     "overview": {
       "list": "Vokabelliste",

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -112,7 +112,7 @@ const BottomTabNavigator = (): JSX.Element | null => {
       <Navigator.Screen
         name='VocabularyCollection'
         component={VocabularyCollectionTabNavigator}
-        options={{ tabBarIcon: renderUserVocabularyTabIcon, title: getLabels().userVocabulary.myWords }}
+        options={{ tabBarIcon: renderUserVocabularyTabIcon, title: getLabels().userVocabulary.collection }}
       />
     </Navigator.Navigator>
   )

--- a/src/navigation/NavigationTypes.ts
+++ b/src/navigation/NavigationTypes.ts
@@ -60,12 +60,9 @@ export type RoutesParams = {
   Home: undefined
   UserVocabularyOverview: undefined
   UserVocabularyProcess: {
-    headerBackLabel: string
     itemToEdit?: VocabularyItem
   }
-  UserVocabularyList: {
-    headerBackLabel: string
-  }
+  UserVocabularyList: undefined
   UserVocabularyDetail: { vocabularyItem: VocabularyItem }
   ScopeSelection: {
     initialSelection: boolean

--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -32,7 +32,7 @@ const UserVocabularyStackNavigator = (): JSX.Element | null => {
       <Stack.Screen
         name='UserVocabularyList'
         component={UserVocabularyListScreen}
-        options={({ navigation, route }) => options(route.params.headerBackLabel, navigation)}
+        options={({ navigation }) => options(back, navigation)}
       />
       <Stack.Screen
         name='VocabularyDetail'
@@ -42,7 +42,7 @@ const UserVocabularyStackNavigator = (): JSX.Element | null => {
       <Stack.Screen
         name='UserVocabularyProcess'
         component={UserVocabularyProcessScreen}
-        options={({ navigation, route }) => options(route.params.headerBackLabel, navigation)}
+        options={({ navigation }) => options(back, navigation)}
       />
       <Stack.Screen
         name='UserVocabularyDisciplineSelection'

--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -23,7 +23,8 @@ const UserVocabularyStackNavigator = (): JSX.Element | null => {
   const theme = useTheme()
 
   return (
-    <Stack.Navigator screenOptions={{ cardStyle: { backgroundColor: theme.colors.background } }}>
+    <Stack.Navigator
+      screenOptions={{ cardStyle: { backgroundColor: theme.colors.background }, headerStatusBarHeight: 0 }}>
       <Stack.Screen
         name='UserVocabularyOverview'
         component={UserVocabularyOverviewScreen}

--- a/src/routes/UserVocabularyOverviewScreen.tsx
+++ b/src/routes/UserVocabularyOverviewScreen.tsx
@@ -27,16 +27,11 @@ type UserVocabularyOverviewScreenProps = {
 }
 
 const UserVocabularyOverviewScreen = ({ navigation }: UserVocabularyOverviewScreenProps): JSX.Element => {
-  const { collection } = getLabels().userVocabulary
   const { list, create, practice } = getLabels().userVocabulary.overview
   return (
     <RouteWrapper>
       <Root>
-        <ListItem
-          icon={<BookIconBlack />}
-          title={list}
-          onPress={() => navigation.navigate('UserVocabularyList', { headerBackLabel: collection })}
-        />
+        <ListItem icon={<BookIconBlack />} title={list} onPress={() => navigation.navigate('UserVocabularyList')} />
         <ListItem
           icon={<BookIconBlack />}
           title={practice}
@@ -44,7 +39,7 @@ const UserVocabularyOverviewScreen = ({ navigation }: UserVocabularyOverviewScre
         />
         <ButtonContainer>
           <Button
-            onPress={() => navigation.navigate('UserVocabularyProcess', { headerBackLabel: collection })}
+            onPress={() => navigation.navigate('UserVocabularyProcess', {})}
             label={create}
             buttonTheme={BUTTONS_THEME.contained}
             iconRight={AddIconWhite}

--- a/src/routes/UserVocabularyOverviewScreen.tsx
+++ b/src/routes/UserVocabularyOverviewScreen.tsx
@@ -27,7 +27,7 @@ type UserVocabularyOverviewScreenProps = {
 }
 
 const UserVocabularyOverviewScreen = ({ navigation }: UserVocabularyOverviewScreenProps): JSX.Element => {
-  const { myWords } = getLabels().userVocabulary
+  const { collection } = getLabels().userVocabulary
   const { list, create, practice } = getLabels().userVocabulary.overview
   return (
     <RouteWrapper>
@@ -35,7 +35,7 @@ const UserVocabularyOverviewScreen = ({ navigation }: UserVocabularyOverviewScre
         <ListItem
           icon={<BookIconBlack />}
           title={list}
-          onPress={() => navigation.navigate('UserVocabularyList', { headerBackLabel: myWords })}
+          onPress={() => navigation.navigate('UserVocabularyList', { headerBackLabel: collection })}
         />
         <ListItem
           icon={<BookIconBlack />}
@@ -44,7 +44,7 @@ const UserVocabularyOverviewScreen = ({ navigation }: UserVocabularyOverviewScre
         />
         <ButtonContainer>
           <Button
-            onPress={() => navigation.navigate('UserVocabularyProcess', { headerBackLabel: myWords })}
+            onPress={() => navigation.navigate('UserVocabularyProcess', { headerBackLabel: collection })}
             label={create}
             buttonTheme={BUTTONS_THEME.contained}
             iconRight={AddIconWhite}

--- a/src/routes/VocabularyDetailScreen.tsx
+++ b/src/routes/VocabularyDetailScreen.tsx
@@ -9,7 +9,6 @@ import VocabularyDetail from '../components/VocabularyDetail'
 import { VOCABULARY_ITEM_TYPES } from '../constants/data'
 import { VocabularyItem } from '../constants/endpoints'
 import { RoutesParams } from '../navigation/NavigationTypes'
-import { getLabels } from '../services/helpers'
 
 type VocabularyDetailScreenProps = {
   route: RouteProp<RoutesParams, 'VocabularyDetail'>
@@ -29,7 +28,6 @@ const EditButton = ({ navigation, vocabularyItem }: EditButtonProps) => (
   <PressableOpacity
     onPress={() =>
       navigation.navigate('UserVocabularyProcess', {
-        headerBackLabel: getLabels().general.back,
         itemToEdit: vocabularyItem,
       })
     }>

--- a/src/routes/process-user-vocabulary/UserVocabularyProcessScreen.tsx
+++ b/src/routes/process-user-vocabulary/UserVocabularyProcessScreen.tsx
@@ -174,7 +174,7 @@ const UserVocabularyProcessScreen = ({ navigation, route }: UserVocabularyProces
         await addUserVocabularyItem(itemToSave)
       }
 
-      navigation.navigate('UserVocabularyList', { headerBackLabel: getLabels().general.back })
+      navigation.navigate('UserVocabularyList')
       resetFields()
     } catch (e) {
       reportError(e)

--- a/src/routes/process-user-vocabulary/__tests__/UserVocabularyProcessScreen.spec.tsx
+++ b/src/routes/process-user-vocabulary/__tests__/UserVocabularyProcessScreen.spec.tsx
@@ -53,7 +53,6 @@ describe('UserVocabularyProcessScreen', () => {
     key: 'key1',
     name: 'UserVocabularyProcess',
     params: {
-      headerBackLabel: 'back',
       itemToEdit,
     },
   })

--- a/src/routes/user-vocabulary-discipline-selection/UserVocabularyDisciplineSelectionScreen.tsx
+++ b/src/routes/user-vocabulary-discipline-selection/UserVocabularyDisciplineSelectionScreen.tsx
@@ -58,7 +58,10 @@ const DisciplineSelectionScreen = ({ navigation }: DisciplineSelectionScreenProp
       <ServerResponseHandler error={error} loading={loading} refresh={refresh}>
         <List
           ListHeaderComponent={
-            <Title title={getLabels().userVocabulary.collection} description={wordsDescription(data?.length ?? 0)} />
+            <Title
+              title={getLabels().userVocabulary.overview.practice}
+              description={wordsDescription(data?.length ?? 0)}
+            />
           }
           data={disciplinesWithVocabulary}
           renderItem={renderListItem}

--- a/src/routes/user-vocabulary-discipline-selection/UserVocabularyDisciplineSelectionScreen.tsx
+++ b/src/routes/user-vocabulary-discipline-selection/UserVocabularyDisciplineSelectionScreen.tsx
@@ -58,7 +58,7 @@ const DisciplineSelectionScreen = ({ navigation }: DisciplineSelectionScreenProp
       <ServerResponseHandler error={error} loading={loading} refresh={refresh}>
         <List
           ListHeaderComponent={
-            <Title title={getLabels().userVocabulary.myWords} description={wordsDescription(data?.length ?? 0)} />
+            <Title title={getLabels().userVocabulary.collection} description={wordsDescription(data?.length ?? 0)} />
           }
           data={disciplinesWithVocabulary}
           renderItem={renderListItem}

--- a/src/routes/user-vocabulary-discipline-selection/__tests__/UserVocabularyDisciplineSelectionScreen.spec.tsx
+++ b/src/routes/user-vocabulary-discipline-selection/__tests__/UserVocabularyDisciplineSelectionScreen.spec.tsx
@@ -26,7 +26,7 @@ describe('UserVocabularyDisciplineSelectionScreen', () => {
 
   it('should render zero disciplines for zero words', () => {
     const { getByText, queryByText } = renderScreen([])
-    expect(getByText(getLabels().userVocabulary.collection)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.overview.practice)).toBeDefined()
     expect(getByText(`0 ${getLabels().general.words}`)).toBeDefined()
     expect(queryByText(`${getLabels().userVocabulary.practice.part} 1`)).toBeNull()
   })

--- a/src/routes/user-vocabulary-discipline-selection/__tests__/UserVocabularyDisciplineSelectionScreen.spec.tsx
+++ b/src/routes/user-vocabulary-discipline-selection/__tests__/UserVocabularyDisciplineSelectionScreen.spec.tsx
@@ -26,7 +26,7 @@ describe('UserVocabularyDisciplineSelectionScreen', () => {
 
   it('should render zero disciplines for zero words', () => {
     const { getByText, queryByText } = renderScreen([])
-    expect(getByText(getLabels().userVocabulary.myWords)).toBeDefined()
+    expect(getByText(getLabels().userVocabulary.collection)).toBeDefined()
     expect(getByText(`0 ${getLabels().general.words}`)).toBeDefined()
     expect(queryByText(`${getLabels().userVocabulary.practice.part} 1`)).toBeNull()
   })
@@ -64,7 +64,7 @@ describe('UserVocabularyDisciplineSelectionScreen', () => {
         description: '',
         numberOfChildren: 10,
         isLeaf: true,
-        parentTitle: getLabels().userVocabulary.myWords,
+        parentTitle: getLabels().userVocabulary.collection,
         needsTrainingSetEndpoint: true,
       },
       disciplineTitle: `${getLabels().userVocabulary.practice.part} 2`,

--- a/src/routes/user-vocabulary-discipline-selection/splitVocabularyToDiscipline.ts
+++ b/src/routes/user-vocabulary-discipline-selection/splitVocabularyToDiscipline.ts
@@ -14,7 +14,7 @@ const createDisciplines = (vocabularySize: number) => {
         description: '',
         numberOfChildren: 1,
         isLeaf: true,
-        parentTitle: getLabels().userVocabulary.myWords,
+        parentTitle: getLabels().userVocabulary.collection,
         needsTrainingSetEndpoint: true,
       },
       vocabulary: [],

--- a/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
+++ b/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
@@ -51,8 +51,7 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
 
   const numberOfVocabularyItems = vocabularyItems.data?.length ?? 0
   const sortedAndFilteredVocabularyItems = getSortedAndFilteredVocabularyItems(vocabularyItems.data, searchString)
-  const { create, collection } = getLabels().userVocabulary
-  const { list } = getLabels().userVocabulary.overview
+  const { create, overview } = getLabels().userVocabulary
   const {
     confirm,
     confirmDeletionPart1,
@@ -101,7 +100,7 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
           ListHeaderComponent={
             <>
               <Title
-                title={collection}
+                title={overview.list}
                 description={`${numberOfVocabularyItems} ${
                   numberOfVocabularyItems === 1 ? getLabels().general.word : getLabels().general.words
                 }`}
@@ -121,7 +120,6 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
               navigateToDetailScreen={() => navigateToDetail(item)}
               navigateToEditScreen={() =>
                 navigation.navigate('UserVocabularyProcess', {
-                  headerBackLabel: getLabels().userVocabulary.collection,
                   itemToEdit: item,
                 })
               }
@@ -135,7 +133,7 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
         {!isKeyboardVisible && (
           <ButtonContainer>
             <Button
-              onPress={() => navigation.navigate('UserVocabularyProcess', { headerBackLabel: list })}
+              onPress={() => navigation.navigate('UserVocabularyProcess', {})}
               label={create}
               buttonTheme={BUTTONS_THEME.contained}
               iconRight={AddIconWhite}

--- a/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
+++ b/src/routes/user-vocabulary-list/UserVocabularyListScreen.tsx
@@ -51,7 +51,7 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
 
   const numberOfVocabularyItems = vocabularyItems.data?.length ?? 0
   const sortedAndFilteredVocabularyItems = getSortedAndFilteredVocabularyItems(vocabularyItems.data, searchString)
-  const { create, myWords } = getLabels().userVocabulary
+  const { create, collection } = getLabels().userVocabulary
   const { list } = getLabels().userVocabulary.overview
   const {
     confirm,
@@ -101,7 +101,7 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
           ListHeaderComponent={
             <>
               <Title
-                title={myWords}
+                title={collection}
                 description={`${numberOfVocabularyItems} ${
                   numberOfVocabularyItems === 1 ? getLabels().general.word : getLabels().general.words
                 }`}
@@ -121,7 +121,7 @@ const UserVocabularyListScreen = ({ navigation }: UserVocabularyListScreenProps)
               navigateToDetailScreen={() => navigateToDetail(item)}
               navigateToEditScreen={() =>
                 navigation.navigate('UserVocabularyProcess', {
-                  headerBackLabel: getLabels().userVocabulary.myWords,
+                  headerBackLabel: getLabels().userVocabulary.collection,
                   itemToEdit: item,
                 })
               }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
In #1062 I forgot to update the labels in the user vocabulary screens, but they did not make too much sense anymore.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change the labels from "Sammlung" to be more specific and user more generic back labels

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1067

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
