### PR TITLE
1039: add favorites to long term excercise

### DIFF
--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -6,6 +6,7 @@ import { StarCircleIconGrey, StarCircleIconGreyFilled } from '../../assets/image
 import { VocabularyItem } from '../constants/endpoints'
 import useLoadAsync from '../hooks/useLoadAsync'
 import { addFavorite, isFavorite as getIsFavorite, removeFavorite } from '../services/AsyncStorage'
+import { vocabularyItemToFavorite } from '../services/helpers'
 import { reportError } from '../services/sentry'
 import PressableOpacity from './PressableOpacity'
 
@@ -27,21 +28,15 @@ type FavoriteButtonProps = {
 }
 
 const FavoriteButton = ({ vocabularyItem, onFavoritesChanged }: FavoriteButtonProps): ReactElement | null => {
-  const favorite = {
-    id: vocabularyItem.id,
-    vocabularyItemType: vocabularyItem.type,
-    ...(vocabularyItem.apiKey && { apiKey: vocabularyItem.apiKey }),
-  }
-
-  const { data: isFavorite, refresh } = useLoadAsync(getIsFavorite, favorite)
+  const { data: isFavorite, refresh } = useLoadAsync(getIsFavorite, vocabularyItemToFavorite(vocabularyItem))
   const theme = useTheme()
   useFocusEffect(refresh)
 
   const onPress = async () => {
     if (isFavorite) {
-      await removeFavorite(favorite).catch(reportError)
+      await removeFavorite(vocabularyItemToFavorite(vocabularyItem)).catch(reportError)
     } else {
-      await addFavorite(favorite).catch(reportError)
+      await addFavorite(vocabularyItem).catch(reportError)
     }
     refresh()
     if (onFavoritesChanged) {

--- a/src/services/AsyncStorage.ts
+++ b/src/services/AsyncStorage.ts
@@ -4,8 +4,9 @@ import { unlink } from 'react-native-fs'
 import { VOCABULARY_ITEM_TYPES, ExerciseKey, Favorite, Progress } from '../constants/data'
 import { VocabularyItem } from '../constants/endpoints'
 import { VocabularyItemResult } from '../navigation/NavigationTypes'
+import { RepetitionService } from './RepetitionService'
 import { CMS, productionCMS, testCMS } from './axios'
-import { calculateScore } from './helpers'
+import { calculateScore, vocabularyItemToFavorite } from './helpers'
 
 const SELECTED_PROFESSIONS_KEY = 'selectedProfessions'
 const CUSTOM_DISCIPLINES_KEY = 'customDisciplines'
@@ -130,11 +131,14 @@ export const getFavorites = async (): Promise<Favorite[]> => {
   return favorites ? JSON.parse(favorites) : []
 }
 
-export const addFavorite = async (favorite: Favorite): Promise<void> => {
+export const addFavorite = async (vocabularyItem: VocabularyItem): Promise<void> => {
+  const favorite = vocabularyItemToFavorite(vocabularyItem)
   const favorites = await getFavorites()
   if (favorites.includes(favorite)) {
     return
   }
+
+  await RepetitionService.addWordToFirstSection(vocabularyItem)
   const newFavorites = [...favorites, favorite]
   await setFavorites(newFavorites)
 }

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -6,6 +6,7 @@ import {
   ARTICLES,
   ExerciseKeys,
   EXERCISES,
+  Favorite,
   FeedbackType,
   NextExercise,
   Progress,
@@ -252,3 +253,9 @@ export const splitTextBySearchString = (allText: string, highlight: string): [st
 
 export const searchProfessions = (disciplines: Discipline[] | undefined, searchKey: string): Discipline[] | undefined =>
   disciplines?.filter(discipline => normalizeString(discipline.title).includes(normalizeString(searchKey)))
+
+export const vocabularyItemToFavorite = (vocabularyItem: VocabularyItem): Favorite => ({
+  id: vocabularyItem.id,
+  vocabularyItemType: vocabularyItem.type,
+  ...(vocabularyItem.apiKey && { apiKey: vocabularyItem.apiKey }),
+})


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Also add words to the long term exercise when they are marked as favorites.
As per issue, they will not be removed from the long term exercise when they are removed as favorites.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add the word to the repetition service in AsyncStorage
- I am not sure if that is the best place to do it, do the reviewers have any opinions on that?

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Bug #1040 now also occurs when a favorite is added, which raises its priority

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1039 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
