### PR TITLE
Fix app freeze when entering a word without article

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-native-pager-view": "^6.7.0",
     "react-native-paper": "5.12.5",
     "react-native-permissions": "^5.1.0",
-    "react-native-popover-view": "^5.1.9",
+    "react-native-popover-view": "^6.1.0",
     "react-native-progress": "^5.0.1",
     "react-native-reanimated": "^3.16.7",
     "react-native-responsive-screen": "^1.4.2",

--- a/release-notes/unreleased/1072.yml
+++ b/release-notes/unreleased/1072.yml
@@ -1,0 +1,6 @@
+issue_key: 1072
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Die App friert nicht mehr ein, wenn ein Wort ohne Artikel eingegeben wurde

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,7 +8496,7 @@ __metadata:
     react-native-pager-view: ^6.7.0
     react-native-paper: 5.12.5
     react-native-permissions: ^5.1.0
-    react-native-popover-view: ^5.1.9
+    react-native-popover-view: ^6.1.0
     react-native-progress: ^5.0.1
     react-native-reanimated: ^3.16.7
     react-native-responsive-screen: ^1.4.2
@@ -10089,13 +10089,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-popover-view@npm:^5.1.9":
-  version: 5.1.9
-  resolution: "react-native-popover-view@npm:5.1.9"
+"react-native-popover-view@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "react-native-popover-view@npm:6.1.0"
   dependencies:
     deprecated-react-native-prop-types: ^2.3.0
     prop-types: ^15.8.1
-  checksum: 64c58f85572564edaafa1ff03903919086bf053c2515eb14e80cf8d19f14c89adb10a06ad672a5aaa91d8a770d4bf8253fa9b0dda8cc3e4e764f62cde9ea2ffc
+  checksum: 1b3c71078b466e5368231384900caaf54ca7aded6edad7cfb8200a2337d5073c07214a0bee8d1741247989270c313d0a9fc7c394098eab5603f6d0a6245f579b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Our popover library does not support reacts new architecture on older versions (https://github.com/SteffeyDev/react-native-popover-view/releases/tag/v6.0.0)

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update the popover library

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Just need to test that the missing article popover shows up.
I also wanted to write a test for that, but for some reason the popover does not show up at all in the dom 🤷 

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1072 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
