### PR TITLE
1079: Fix word cut off on favorite view on IOS

### DIFF
--- a/src/components/VocabularyDetail.tsx
+++ b/src/components/VocabularyDetail.tsx
@@ -7,7 +7,6 @@ import WordItem from './WordItem'
 
 const ItemContainer = styled.View`
   margin-top: ${props => props.theme.spacings.xl};
-  height: 10%;
   width: 85%;
   align-self: center;
 `

--- a/src/navigation/FavoritesStackNavigator.tsx
+++ b/src/navigation/FavoritesStackNavigator.tsx
@@ -14,7 +14,7 @@ const FavoritesStackNavigator = (): ReactElement => {
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={{ headerStatusBarHeight: 0 }}>
       <Stack.Screen name='Favorites' component={FavoritesScreen} options={{ headerShown: false }} />
       <Stack.Screen
         name='VocabularyDetail'


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The favorite view had the same problem as the user vocabulary view (Fixed in commit 895bbec853b3433202daffaf01ee4268d4ed77da)

This pr applies the same fix to the favorites stack navigator.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- In the favorite stack navigator, explicitly set the header height to 0, so that the content does not have unnecessary padding applied to it.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should not change anything on android devices

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1079 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
