### PR TITLE
Fix volume icon not greyed out correctly

### DIFF
--- a/assets/images/volume-up-circle-icon.svg
+++ b/assets/images/volume-up-circle-icon.svg
@@ -1,34 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="40" viewBox="0 0 40 40">
-    <defs>
-        <filter id="4ebtzun4sa" width="177.5%" height="177.5%" x="-38.8%" y="-36.2%" filterUnits="objectBoundingBox">
-            <feMorphology in="SourceAlpha" radius=".5" result="shadowSpreadOuter1"/>
-            <feOffset dy="2" in="shadowSpreadOuter1" result="shadowOffsetOuter1"/>
-            <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="2"/>
-            <feColorMatrix in="shadowBlurOuter1" result="shadowMatrixOuter1" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
-            <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter2"/>
-            <feGaussianBlur in="shadowOffsetOuter2" result="shadowBlurOuter2" stdDeviation="5"/>
-            <feColorMatrix in="shadowBlurOuter2" result="shadowMatrixOuter2" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.12 0"/>
-            <feOffset dy="4" in="SourceAlpha" result="shadowOffsetOuter3"/>
-            <feGaussianBlur in="shadowOffsetOuter3" result="shadowBlurOuter3" stdDeviation="2.5"/>
-            <feColorMatrix in="shadowBlurOuter3" result="shadowMatrixOuter3" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.14 0"/>
-            <feMerge>
-                <feMergeNode in="shadowMatrixOuter1"/>
-                <feMergeNode in="shadowMatrixOuter2"/>
-                <feMergeNode in="shadowMatrixOuter3"/>
-            </feMerge>
-        </filter>
-        <circle id="58iscwcg6b" cx="20" cy="20" r="20"/>
-    </defs>
-    <g fill-rule="evenodd">
-        <g>
-            <g transform="translate(-140 -226) translate(140 226)">
-                <use filter="url(#4ebtzun4sa)" xlink:href="#58iscwcg6b"/>
-                <circle cx="20" cy="20" r="20"/>
-                <circle cx="20" cy="20" r="20" />
-                <g fill="#F9FAFB">
-                    <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z" transform="translate(8 8)"/>
-                </g>
-            </g>
-        </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+    <g fill-rule="evenodd" transform="translate(-140 -226) translate(140 226)" fill="#F9FAFB">
+        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"
+              transform="translate(8 8)"/>
     </g>
 </svg>

--- a/release-notes/unreleased/1083-speaker-button-not-greyed-out.yml
+++ b/release-notes/unreleased/1083-speaker-button-not-greyed-out.yml
@@ -1,0 +1,6 @@
+issue_key: 1083
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Der Lautsprecher-Button zeigt in Übungen nun an, ob er aktiviert werden kann


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Turns out we were already using the correct colors for the icon, but they were fully covered by the background of the icon…

This pr simplifies the svg icon by removing the background from it.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove background from assets/images/volume-up-circle-icon.svg

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The colors that were already being applied to the background should now show up

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1083 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
