### PR TITLE
Update issue templates to use issue types instead of labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "Bug Report \U0001F41B"
 about: Report a bug to help us to fix and improve the app
-labels: bug
+type: Bug
 ---
 
 ### Describe the Bug

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,7 +1,7 @@
 ---
 name: "Task \U0001F527"
 about: Suggest an idea or enhancement for this project
-labels: Task
+type: Task
 ---
 
 ### Describe the Problem

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,9 +1,7 @@
 ---
 name: User Story
 about: Bundle multiple tasks/ideas into one user story
-title: ''
-labels: Story
-assignees: ''
+type: Story
 ---
 
 As a user I want XYZ such that XYZ.


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
We have updated all open issues with labels `task`, `bug`, or `Story` to use types instead. Now the issue templates should be updated too.

The changes are untested, but I am hoping that this documentation is accurate: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Switch from labels to types in the issue templates

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1090 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
