### PR TITLE
Small debug modal improvements

### DIFF
--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -217,7 +217,8 @@
       "changeCMS": "change cms",
       "enableDevMode": "Enable DevMode",
       "disableDevMode": "Disable DevMode",
-      "fillRepetitionExerciseWithData": "Fill repetition exercise with data"
+      "fillRepetitionExerciseWithData": "Fill repetition exercise with data",
+      "clearProfessions": "Clear selected professions"
     }
   },
   "sponsors": {

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -211,6 +211,7 @@
     "appStability": "App Stabilität",
     "appStabilityExplanation": "Durch das automatische Senden von Fehlerberichten die Lunes App verbessern",
     "version": "Version",
+    "devSettings": "Dev settings",
     "debugModal": {
       "sentry": "Send Sentry Error",
       "currentCMS": "current cms",

--- a/src/routes/settings/SettingsScreen.tsx
+++ b/src/routes/settings/SettingsScreen.tsx
@@ -2,9 +2,11 @@ import React, { ReactElement, useState } from 'react'
 import { Switch } from 'react-native'
 import styled from 'styled-components/native'
 
+import Button from '../../components/Button'
 import RouteWrapper from '../../components/RouteWrapper'
 import { Content, ContentTextLight } from '../../components/text/Content'
 import { Heading } from '../../components/text/Heading'
+import { BUTTONS_THEME } from '../../constants/data'
 import useStorage from '../../hooks/useStorage'
 import { getLabels } from '../../services/helpers'
 import DebugModal from './components/DebugModal'
@@ -31,6 +33,9 @@ const SettingsScreen = (): ReactElement => {
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
 
   const [trackingEnabled, setTrackingEnabled] = useStorage('isTrackingEnabled')
+  const [isDevModeEnabled] = useStorage('isDevModeEnabled')
+
+  const { settings, appStability, appStabilityExplanation, devSettings } = getLabels().settings
 
   const onTrackingChange = async (): Promise<void> => {
     const newValue = !trackingEnabled
@@ -39,15 +44,24 @@ const SettingsScreen = (): ReactElement => {
 
   return (
     <RouteWrapper>
-      <DebugModal visible={isModalVisible} onClose={() => setIsModalVisible(false)} />
-      <SettingsHeading>{getLabels().settings.settings}</SettingsHeading>
+      <DebugModal
+        isCodeRequired={!isDevModeEnabled}
+        visible={isModalVisible}
+        onClose={() => setIsModalVisible(false)}
+      />
+      <SettingsHeading>{settings}</SettingsHeading>
       <ItemContainer>
         <ItemTextContainer>
-          <Content>{getLabels().settings.appStability}</Content>
-          <ContentTextLight>{getLabels().settings.appStabilityExplanation}</ContentTextLight>
+          <Content>{appStability}</Content>
+          <ContentTextLight>{appStabilityExplanation}</ContentTextLight>
         </ItemTextContainer>
         <Switch testID='tracking-switch' value={trackingEnabled} onChange={onTrackingChange} />
       </ItemContainer>
+      {isDevModeEnabled && (
+        <ItemContainer>
+          <Button onPress={() => setIsModalVisible(true)} label={devSettings} buttonTheme={BUTTONS_THEME.contained} />
+        </ItemContainer>
+      )}
       <VersionPressable onClickThresholdReached={() => setIsModalVisible(true)} />
     </RouteWrapper>
   )

--- a/src/routes/settings/components/DebugModal.tsx
+++ b/src/routes/settings/components/DebugModal.tsx
@@ -27,13 +27,14 @@ const CodeInput = styled.TextInput`
 `
 
 type DebugModalProps = {
+  isCodeRequired: boolean
   visible: boolean
   onClose: () => void
 }
 
 const DebugModal = (props: DebugModalProps): JSX.Element => {
   const storageCache = useStorageCache()
-  const { visible, onClose } = props
+  const { isCodeRequired, visible, onClose } = props
   const [inputText, setInputText] = useState<string>('')
   const UNLOCKING_TEXT = 'wirschaffendas'
   const [isDevModeEnabled, setIsDevModeEnabled] = useStorage('isDevModeEnabled')
@@ -90,7 +91,7 @@ const DebugModal = (props: DebugModalProps): JSX.Element => {
   return (
     <ModalSkeleton testID='debug-modal' visible={visible} onClose={resetTextAndClose}>
       <CodeInput placeholder='Development Code' onChangeText={setInputText} />
-      {inputText.toLowerCase() === UNLOCKING_TEXT && (
+      {(!isCodeRequired || inputText.toLowerCase() === UNLOCKING_TEXT) && (
         <Container>
           <Button label={sentry} onPress={throwSentryError} buttonTheme={BUTTONS_THEME.contained} />
           <Subheading>{currentCMS}:</Subheading>

--- a/src/routes/settings/components/DebugModal.tsx
+++ b/src/routes/settings/components/DebugModal.tsx
@@ -37,12 +37,20 @@ const DebugModal = (props: DebugModalProps): JSX.Element => {
   const [inputText, setInputText] = useState<string>('')
   const UNLOCKING_TEXT = 'wirschaffendas'
   const [isDevModeEnabled, setIsDevModeEnabled] = useStorage('isDevModeEnabled')
-  const { sentry, currentCMS, changeCMS, disableDevMode, enableDevMode, fillRepetitionExerciseWithData } =
-    getLabels().settings.debugModal
+  const {
+    sentry,
+    currentCMS,
+    changeCMS,
+    disableDevMode,
+    enableDevMode,
+    fillRepetitionExerciseWithData,
+    clearProfessions,
+  } = getLabels().settings.debugModal
   const repetitionService = useRepetitionService()
 
   const [cmsUrlOverwrite, setCmsUrlOverwrite] = useStorage('cmsUrlOverwrite')
   const baseURL = getBaseURL(cmsUrlOverwrite)
+  const [_, setSelectedProfessions] = useStorage('selectedProfessions')
 
   const throwSentryError = (): void => {
     reportError('Error for testing Sentry')
@@ -61,6 +69,10 @@ const DebugModal = (props: DebugModalProps): JSX.Element => {
 
   const doToggleDevMode = async (): Promise<void> => {
     await setIsDevModeEnabled(!isDevModeEnabled)
+  }
+
+  const resetProfessions = async (): Promise<void> => {
+    await setSelectedProfessions(null)
   }
 
   const NUMBER_OF_TEST_VOCABULARY = 5
@@ -94,6 +106,7 @@ const DebugModal = (props: DebugModalProps): JSX.Element => {
             label={fillRepetitionExerciseWithData}
             buttonTheme={BUTTONS_THEME.contained}
           />
+          <Button onPress={resetProfessions} label={clearProfessions} buttonTheme={BUTTONS_THEME.contained} />
         </Container>
       )}
     </ModalSkeleton>

--- a/src/routes/settings/components/__tests__/DebugModal.spec.tsx
+++ b/src/routes/settings/components/__tests__/DebugModal.spec.tsx
@@ -8,7 +8,7 @@ import DebugModal from '../DebugModal'
 
 describe('DebugModal', () => {
   it('should show buttons only for correct text input', async () => {
-    const { queryByText, getByPlaceholderText } = render(<DebugModal visible onClose={jest.fn()} />)
+    const { queryByText, getByPlaceholderText } = render(<DebugModal isCodeRequired visible onClose={jest.fn()} />)
     expect(queryByText(getLabels().settings.debugModal.sentry)).toBeNull()
     const textField = getByPlaceholderText('Development Code')
     await act(async () => {
@@ -18,7 +18,7 @@ describe('DebugModal', () => {
   })
 
   it('should show and switch cms url', async () => {
-    const { getByText, getByPlaceholderText } = render(<DebugModal visible onClose={jest.fn()} />)
+    const { getByText, getByPlaceholderText } = render(<DebugModal isCodeRequired visible onClose={jest.fn()} />)
     const textField = getByPlaceholderText('Development Code')
     await act(async () => {
       fireEvent.changeText(textField, 'wirschaffendas')
@@ -37,7 +37,9 @@ describe('DebugModal', () => {
   })
 
   it('should show and toggle devmode status', async () => {
-    const { queryByText, getByText, getByPlaceholderText } = render(<DebugModal visible onClose={jest.fn()} />)
+    const { queryByText, getByText, getByPlaceholderText } = render(
+      <DebugModal isCodeRequired visible onClose={jest.fn()} />,
+    )
     const textField = getByPlaceholderText('Development Code')
 
     await act(async () => {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This pr contains two small improvements to the debug modal

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add a setting to the debug modal to clear the selected professions. This makes it a bit easier to test the welcome screen on ios
- Add a debug settings button to the main settings if dev mode is already enabled. This avoids having to type the pass phrase every time

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- There should not be any side effects if dev mode is disabled



---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
