### PR TITLE
Remove unused ios permission

### DIFF
--- a/ios/Lunes/Info.plist
+++ b/ios/Lunes/Info.plist
@@ -44,8 +44,6 @@
     <string>Zur Aufnahme von Bildern benötigt LUNES Zugriff auf deine Kamera.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Zur Aufnahme von Audios benötigt LUNES Zugriff auf dein Mikrofon.</string>
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string></string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Zur Auswahl von Bildern benötigt LUNES Zugriff auf deine Bildergalerie.</string>
     <key>UIAppFonts</key>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
- We don't need the location permission for the lunes app, and the android variant does also not declare it
- Not sure why it was here in the first place though

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the permission from the ios manifest

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
App should still work

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1082

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
