### PR TITLE
Enable tts for ios

### DIFF
--- a/release-notes/unreleased/1089-tts-does-not-work-on-ios.yml
+++ b/release-notes/unreleased/1089-tts-does-not-work-on-ios.yml
@@ -1,0 +1,5 @@
+issue_key: 1089
+show_in_stores: true
+platforms:
+  - ios
+de: Die Text-zu-Sprache Funktionalität wird jetzt auch auf ios unterstützt

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -41,13 +41,9 @@ const AudioPlayer = ({ audio, disabled, isTtsText = false }: AudioPlayerProps): 
 
   const initializeTts = useCallback((): void => {
     Tts.getInitStatus()
-      .then(async status => {
-        // Status does not have to be 'success'
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (status === 'success') {
-          setIsInitialized(true)
-          await Tts.setDefaultLanguage('de-DE')
-        }
+      .then(async () => {
+        setIsInitialized(true)
+        await Tts.setDefaultLanguage('de-DE')
       })
       .catch(async (error: TtsError) => {
         /* eslint-disable-next-line no-console */


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Tts not working on ios was a bug actually. It did not work because the tts engine returns `true` instead of `'success'` for some reason. I think this fix to just remove the check should work, because this is how it is suggested in the repo: https://github.com/ak1394/react-native-tts?tab=readme-ov-file#waiting-for-initialization


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the check for the status code after initialization. Errors should be reported in the `.catch(...)` part

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
I tested this on ios, android and an android without a tts engine, and everything seemed to work as expected

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1089

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
