### PR TITLE
Move words to long term memory exercise after first level

### DIFF
--- a/release-notes/unreleased/1088-move-words-to-long-term-memory-exercise-after-each-level.yml
+++ b/release-notes/unreleased/1088-move-words-to-long-term-memory-exercise-after-each-level.yml
@@ -1,0 +1,6 @@
+issue_key: 1088
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Wörter können jetzt bereits ab dem zweiten Level wiederholt werden

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -13,6 +13,8 @@ export const ExerciseKeys = {
 } as const
 export type ExerciseKey = (typeof ExerciseKeys)[keyof typeof ExerciseKeys]
 
+export const FIRST_EXERCISE_FOR_REPETITION = ExerciseKeys.wordChoiceExercise
+
 export type Exercise = {
   key: ExerciseKey
   title: string

--- a/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
+++ b/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
@@ -24,7 +24,12 @@ import RoundedBackground from '../../components/RoundedBackground'
 import RouteWrapper from '../../components/RouteWrapper'
 import { Content } from '../../components/text/Content'
 import { HeadingBackground } from '../../components/text/Heading'
-import { BUTTONS_THEME, EXERCISES, SCORE_THRESHOLD_POSITIVE_FEEDBACK } from '../../constants/data'
+import {
+  BUTTONS_THEME,
+  EXERCISES,
+  FIRST_EXERCISE_FOR_REPETITION,
+  SCORE_THRESHOLD_POSITIVE_FEEDBACK,
+} from '../../constants/data'
 import theme from '../../constants/theme'
 import { Color } from '../../constants/theme/colors'
 import { RoutesParams } from '../../navigation/NavigationTypes'
@@ -146,7 +151,7 @@ const ExerciseFinishedScreen = ({ navigation, route }: ExerciseFinishedScreenPro
       backgroundColor={unlockedNextExercise ? theme.colors.correct : theme.colors.primary}
       lightStatusBarContent={!unlockedNextExercise}
       bottomBackgroundColor={theme.colors.background}>
-      {exercise === EXERCISES.length - 1 && (
+      {exercise === FIRST_EXERCISE_FOR_REPETITION && (
         <Modal
           visible={isModalVisible}
           confirmationAction={() => navigation.navigate('RepetitionTab')}

--- a/src/routes/exercise-finished/__tests__/ExerciseFinishedScreen.spec.tsx
+++ b/src/routes/exercise-finished/__tests__/ExerciseFinishedScreen.spec.tsx
@@ -2,7 +2,7 @@ import { CommonActions, RouteProp } from '@react-navigation/native'
 import { fireEvent } from '@testing-library/react-native'
 import React from 'react'
 
-import { ExerciseKey, EXERCISES } from '../../../constants/data'
+import { ExerciseKey, EXERCISES, FIRST_EXERCISE_FOR_REPETITION } from '../../../constants/data'
 import { RoutesParams } from '../../../navigation/NavigationTypes'
 import { getLabels } from '../../../services/helpers'
 import VocabularyItemBuilder from '../../../testing/VocabularyItemBuilder'
@@ -38,7 +38,7 @@ describe('ExerciseFinishedScreen', () => {
   })
 
   it('should render repetition modal if a module is finished', () => {
-    const route = getRoute(3, true, true)
+    const route = getRoute(FIRST_EXERCISE_FOR_REPETITION, true, true)
     const { getByText } = render(<ExerciseFinishedScreen route={route} navigation={navigation} />)
     expect(getByText(getLabels().repetition.hintModalHeaderText)).toBeDefined()
     expect(getByText(getLabels().repetition.hintModalContentText)).toBeDefined()
@@ -48,15 +48,15 @@ describe('ExerciseFinishedScreen', () => {
   })
 
   it('should not render repetition modal if it is on a first exercise', () => {
-    const route = getRoute(1, true, true)
+    const route = getRoute(0, true, true)
     const { queryByTestId } = render(<ExerciseFinishedScreen route={route} navigation={navigation} />)
     expect(queryByTestId('repetition-modal')).toBeNull()
   })
 
-  it('should not render repetition modal if it is on a second exercise', () => {
-    const route = getRoute(2, false, false)
+  it('should render repetition modal if it is on a second exercise', () => {
+    const route = getRoute(1, false, false)
     const { queryByTestId } = render(<ExerciseFinishedScreen route={route} navigation={navigation} />)
-    expect(queryByTestId('repetition-modal')).toBeNull()
+    expect(queryByTestId('repetition-modal')).toBeTruthy()
   })
 
   it('should render and handle button click for unlocked next exercise', () => {

--- a/src/routes/write-exercise/__tests__/WriteExerciseScreen.spec.tsx
+++ b/src/routes/write-exercise/__tests__/WriteExerciseScreen.spec.tsx
@@ -179,7 +179,6 @@ describe('WriteExerciseScreen', () => {
       { vocabularyItem: vocabularyItems[0], result: SIMPLE_RESULTS.correct, numberOfTries: 1 },
       { vocabularyItem: vocabularyItems[1], result: SIMPLE_RESULTS.correct, numberOfTries: 1 },
     ])
-    expect(storageCache.getItem('wordNodeCards')).toHaveLength(2)
   })
 
   const evaluate = (input: string, expectedFeedback: string) => {

--- a/src/routes/write-exercise/services/RepetitionWriteExerciseService.ts
+++ b/src/routes/write-exercise/services/RepetitionWriteExerciseService.ts
@@ -21,10 +21,7 @@ class RepetitionWriteExerciseService extends AbstractWriteExerciseService {
   ) {
     super(route, navigation, setCurrentIndex, setIsAnswerSubmitted, setVocabularyItemWithResults, storageCache)
 
-    this.repetitionService = new RepetitionService(
-      () => storageCache.getItem('wordNodeCards'),
-      value => storageCache.setItem('wordNodeCards', value),
-    )
+    this.repetitionService = RepetitionService.fromStorageCache(this.storageCache)
   }
 
   finishExercise = async (): Promise<void> => {

--- a/src/routes/write-exercise/services/StandardWriteExerciseService.ts
+++ b/src/routes/write-exercise/services/StandardWriteExerciseService.ts
@@ -1,7 +1,6 @@
 import { ExerciseKeys, SimpleResult } from '../../../constants/data'
 import { VocabularyItem } from '../../../constants/endpoints'
 import { VocabularyItemResult } from '../../../navigation/NavigationTypes'
-import { RepetitionService } from '../../../services/RepetitionService'
 import { saveExerciseProgress } from '../../../services/storageUtils'
 import AbstractWriteExerciseService from './AbstractWriteExerciseService'
 
@@ -9,12 +8,6 @@ class StandardWriteExerciseService extends AbstractWriteExerciseService {
   finishExercise = async (results: VocabularyItemResult[], vocabularyItems: VocabularyItem[]): Promise<void> => {
     if (this.route.params.contentType === 'standard') {
       await saveExerciseProgress(this.storageCache, this.route.params.disciplineId, ExerciseKeys.writeExercise, results)
-
-      const repetitionService = new RepetitionService(
-        () => this.storageCache.getItem('wordNodeCards'),
-        value => this.storageCache.setItem('wordNodeCards', value),
-      )
-      await repetitionService.addWordsToFirstSection(vocabularyItems)
     }
     this.navigation.navigate('ExerciseFinished', {
       ...this.route.params,

--- a/src/services/RepetitionService.ts
+++ b/src/services/RepetitionService.ts
@@ -1,6 +1,7 @@
 import { VocabularyItem } from '../constants/endpoints'
 import { VocabularyItemResult } from '../navigation/NavigationTypes'
 import NotificationService from './NotificationService'
+import { StorageCache } from './Storage'
 import { millisecondsToDays } from './helpers'
 
 /* eslint-disable no-magic-numbers */
@@ -30,6 +31,12 @@ export class RepetitionService {
     this.getWordNodeCards = getWordNodeCards
     this.setWordNodeCardsWithoutReminder = setWordNodeCardsWithoutReminder
   }
+
+  public static fromStorageCache = (storageCache: StorageCache): RepetitionService =>
+    new RepetitionService(
+      () => storageCache.getItem('wordNodeCards'),
+      value => storageCache.setItem('wordNodeCards', value),
+    )
 
   public getWordNodeCard = (word: VocabularyItem): WordNodeCard | undefined =>
     this.getWordNodeCards().find(wordNodeCard => wordNodeCard.word === word)

--- a/src/services/__tests__/RepetitionService.spec.ts
+++ b/src/services/__tests__/RepetitionService.spec.ts
@@ -15,10 +15,7 @@ describe('RepetitionService', () => {
   let testData: WordNodeCard[] = []
 
   const storageCache = StorageCache.createDummy()
-  const repetitionService = new RepetitionService(
-    () => storageCache.getItem('wordNodeCards'),
-    value => storageCache.setItem('wordNodeCards', value),
-  )
+  const repetitionService = RepetitionService.fromStorageCache(storageCache)
 
   beforeEach(() => {
     storageCache.setItem('wordNodeCards', [])

--- a/src/services/__tests__/storageUtils.spec.ts
+++ b/src/services/__tests__/storageUtils.spec.ts
@@ -121,9 +121,29 @@ describe('storageUtils', () => {
             numberOfTries: 3,
           },
         ]
-        await saveExerciseProgress(storageCache, 1, 1, vocabularyItemResults)
+        await saveExerciseProgress(storageCache, 1, ExerciseKeys.wordChoiceExercise, vocabularyItemResults)
         const progress = storageCache.getItem('progress')
         expect(progress[1]).toStrictEqual({ [ExerciseKeys.wordChoiceExercise]: 5 })
+
+        const words = repetitionService.getWordNodeCards()
+        expect(words).toHaveLength(2)
+      })
+
+      it('should not update the repetition words for the first level', async () => {
+        const vocabularyItems = new VocabularyItemBuilder(2).build()
+        const vocabularyItemResults: VocabularyItemResult[] = [
+          {
+            vocabularyItem: vocabularyItems[0],
+            result: SIMPLE_RESULTS.correct,
+            numberOfTries: 1,
+          },
+        ]
+        await saveExerciseProgress(storageCache, 1, ExerciseKeys.vocabularyList, vocabularyItemResults)
+        const progress = storageCache.getItem('progress')
+        expect(progress[1]).toStrictEqual({ [ExerciseKeys.vocabularyList]: 10 })
+
+        const words = repetitionService.getWordNodeCards()
+        expect(words).toHaveLength(0)
       })
     })
   })

--- a/src/services/__tests__/storageUtils.spec.ts
+++ b/src/services/__tests__/storageUtils.spec.ts
@@ -29,10 +29,7 @@ describe('storageUtils', () => {
 
   beforeEach(() => {
     storageCache = StorageCache.createDummy()
-    repetitionService = new RepetitionService(
-      () => storageCache.getItem('wordNodeCards'),
-      value => storageCache.setItem('wordNodeCards', value),
-    )
+    repetitionService = RepetitionService.fromStorageCache(storageCache)
   })
 
   describe('customDisciplines', () => {

--- a/src/services/__tests__/url.spec.ts
+++ b/src/services/__tests__/url.spec.ts
@@ -11,10 +11,9 @@ jest.mock('react-native', () => ({
 }))
 
 jest.mock('react-native-responsive-screen', () => ({
-  heightPercentageToDP: jest.fn((value) => value),
-  widthPercentageToDP: jest.fn((value) => value),
+  heightPercentageToDP: jest.fn(value => value),
+  widthPercentageToDP: jest.fn(value => value),
 }))
-
 
 describe('url', () => {
   it('should successfully open an url', async () => {

--- a/src/services/__tests__/url.spec.ts
+++ b/src/services/__tests__/url.spec.ts
@@ -10,6 +10,12 @@ jest.mock('react-native', () => ({
   },
 }))
 
+jest.mock('react-native-responsive-screen', () => ({
+  heightPercentageToDP: jest.fn((value) => value),
+  widthPercentageToDP: jest.fn((value) => value),
+}))
+
+
 describe('url', () => {
   it('should successfully open an url', async () => {
     mocked(Linking.canOpenURL).mockResolvedValueOnce(true)

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { unlink } from 'react-native-fs'
 
-import { ExerciseKey, Favorite, VOCABULARY_ITEM_TYPES } from '../constants/data'
+import { ExerciseKey, ExerciseKeys, Favorite, VOCABULARY_ITEM_TYPES } from '../constants/data'
 import { UserVocabularyItem, VocabularyItem } from '../constants/endpoints'
 import { VocabularyItemResult } from '../navigation/NavigationTypes'
 import { RepetitionService } from './RepetitionService'
@@ -60,6 +60,12 @@ export const saveExerciseProgress = async (
 ): Promise<void> => {
   const score = calculateScore(vocabularyItemsWithResults)
   await setExerciseProgress(storageCache, disciplineId, exerciseKey, score)
+
+  if (exerciseKey > ExerciseKeys.vocabularyList && score > 0) {
+    const repetitionService = RepetitionService.fromStorageCache(storageCache)
+    const words = vocabularyItemsWithResults.map(result => result.vocabularyItem)
+    await repetitionService.addWordsToFirstSection(words)
+  }
 }
 
 const compareFavorites = (favorite1: Favorite, favorite2: Favorite) =>

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { unlink } from 'react-native-fs'
 
-import { ExerciseKey, ExerciseKeys, Favorite, VOCABULARY_ITEM_TYPES } from '../constants/data'
+import { ExerciseKey, Favorite, FIRST_EXERCISE_FOR_REPETITION, VOCABULARY_ITEM_TYPES } from '../constants/data'
 import { UserVocabularyItem, VocabularyItem } from '../constants/endpoints'
 import { VocabularyItemResult } from '../navigation/NavigationTypes'
 import { RepetitionService } from './RepetitionService'
@@ -61,7 +61,7 @@ export const saveExerciseProgress = async (
   const score = calculateScore(vocabularyItemsWithResults)
   await setExerciseProgress(storageCache, disciplineId, exerciseKey, score)
 
-  if (exerciseKey > ExerciseKeys.vocabularyList && score > 0) {
+  if (exerciseKey >= FIRST_EXERCISE_FOR_REPETITION && score > 0) {
     const repetitionService = RepetitionService.fromStorageCache(storageCache)
     const words = vocabularyItemsWithResults.map(result => result.vocabularyItem)
     await repetitionService.addWordsToFirstSection(words)


### PR DESCRIPTION
### Short Description

This pr changes the behavior of when new words are added to the long term memory exercise. Before, this only happened when every level was completed and now it will happen after the second level (every level except the word list)
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move the functionality to add words to the long term memory exercise to the `saveExerciseProgress` function
- Adjust tests
- Adjust when the repetition reminder is shown

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1088

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
