### PR TITLE
Rename `disciplineOverview` button to `back`

### DIFF
--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -113,7 +113,7 @@
       "nextExercise": "Nächste Übung",
       "continue": "Weitermachen",
       "repeat": "Übung wiederholen",
-      "disciplineOverview": "Zur Modulübersicht",
+      "back": "Zurück",
       "backToWordlist": "Zurück zur Wortliste"
     },
     "of": "von",

--- a/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
+++ b/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
@@ -125,7 +125,7 @@ const ExerciseFinishedScreen = ({ navigation, route }: ExerciseFinishedScreenPro
       return {
         message: getLabels().results.finishedDiscipline,
         resultColor: theme.colors.correct,
-        buttonText: getLabels().results.action.disciplineOverview,
+        buttonText: getLabels().results.action.back,
         navigationAction: navigateToNextDiscipline,
         ResultIcon: PartyHornIcon,
       }

--- a/src/routes/exercise-finished/__tests__/ExerciseFinishedScreen.spec.tsx
+++ b/src/routes/exercise-finished/__tests__/ExerciseFinishedScreen.spec.tsx
@@ -115,7 +115,7 @@ describe('ExerciseFinishedScreen', () => {
     const route = getRoute(3, true, true)
     const { getByText } = render(<ExerciseFinishedScreen route={route} navigation={navigation} />)
     expect(getByText(getLabels().results.finishedDiscipline)).toBeDefined()
-    const button = getByText(getLabels().results.action.disciplineOverview)
+    const button = getByText(getLabels().results.action.back)
     fireEvent.press(button)
     expect(navigation.pop).toHaveBeenCalledWith(2)
   })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The previous label was not accurate because it only takes you back to the discipline overview if you started the exercise from there

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Rename the button

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #946 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
