### PR TITLE
Update target sdk to 35

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "26.1.10909125"
         kotlinVersion = "1.9.25"
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1328,7 +1328,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.14.1):
+  - react-native-safe-area-context (5.5.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1341,8 +1341,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 4.14.1)
-    - react-native-safe-area-context/fabric (= 4.14.1)
+    - react-native-safe-area-context/common (= 5.5.1)
+    - react-native-safe-area-context/fabric (= 5.5.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1351,7 +1351,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (4.14.1):
+  - react-native-safe-area-context/common (5.5.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1372,7 +1372,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (4.14.1):
+  - react-native-safe-area-context/fabric (5.5.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2350,7 +2350,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: d80ff86c8902872d397d9622f1a97aadcc12cead
   react-native-image-picker: dbc35687199a8bf89514e09b6b105557f9f63162
   react-native-pager-view: 07588127199ef1a055549d5cdd19cacd9ddca390
-  react-native-safe-area-context: 7952193294b10a6a99a9546de0db0c8496210ffa
+  react-native-safe-area-context: 396b0eabb458be90bdce891f81593b00b2c1647b
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
   React-NativeModulesApple: cebca2e5320a3d66e123cade23bd90a167ffce5e
   React-perflogger: 72e653eb3aba9122f9e57cf012d22d2486f33358
@@ -2401,4 +2401,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 15651b8fd6741c5d7dc4e0a7399d820b2bab5596
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-native-progress": "^5.0.1",
     "react-native-reanimated": "^3.16.7",
     "react-native-responsive-screen": "^1.4.2",
-    "react-native-safe-area-context": "^4.14.0",
+    "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "^3.35.0",
     "react-native-sound-player": "0.14.3",
     "react-native-svg": "^15.9.0",

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -65,7 +65,7 @@ const BottomTabNavigator = (): JSX.Element | null => {
         tabBarActiveTintColor: theme.colors.background,
         tabBarStyle: {
           backgroundColor: theme.colors.primary,
-          minHeight: hp('7%'),
+          minHeight: hp('7%') + insets.bottom,
           paddingBottom: insets.bottom,
         },
         tabBarItemStyle: { height: hp('7%'), padding: theme.spacingsPlain.xs },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8417,7 +8417,7 @@ __metadata:
     react-native-progress: ^5.0.1
     react-native-reanimated: ^3.16.7
     react-native-responsive-screen: ^1.4.2
-    react-native-safe-area-context: ^4.14.0
+    react-native-safe-area-context: ^5.5.1
     react-native-screens: ^3.35.0
     react-native-sound-player: 0.14.3
     react-native-svg: ^15.9.0
@@ -10080,13 +10080,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:^4.14.0":
-  version: 4.14.1
-  resolution: "react-native-safe-area-context@npm:4.14.1"
+"react-native-safe-area-context@npm:^5.5.1":
+  version: 5.5.1
+  resolution: "react-native-safe-area-context@npm:5.5.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: c34c6fe9002a89c80ddb206fc68db99f1e432e19c7cf5aaa93b430584051b7e7caf889093224029437dc5b66fe434b09e9950d755aa40b58e1e3a1f976c2fec1
+  checksum: 603d9f4cdfd34b494ae64dbcbcd57f306271b9843971c0fb820e8d50e6470f63cdd06472536e8ff9668f79a33c3d1ef32741ed6fe71ca81b093ec01ac99054f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This is required by google, so that we can continue pushing updates

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update the target sdk to 35
- Update `react-native-safe-area-context`
- Fix calculation of bottom tab bar height

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- As a side effect of android sdk 35, edge to edge navigation is now enabled by default. To me everything looks fine (except the one small bug with the height calculation of the bottom tab bar height that I fixed), but worst case we could also disable it again
- Potentially other side effects of the new sdk, but I did not find any

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1104

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
