### PR TITLE
Fix overlap of content on android

### DIFF
--- a/src/components/SafeBottomPadding.tsx
+++ b/src/components/SafeBottomPadding.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import styled from 'styled-components/native'
+
+const Padding = styled.View<{ bottom: number }>`
+  padding: ${props => props.bottom}px;
+`
+
+const SafeBottomPadding = (): JSX.Element => {
+  const insets = useSafeAreaInsets()
+
+  return <Padding bottom={insets.bottom} />
+}
+
+export default SafeBottomPadding

--- a/src/components/VocabularyList.tsx
+++ b/src/components/VocabularyList.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { VocabularyItem } from '../constants/endpoints'
 import { getLabels } from '../services/helpers'
+import SafeBottomPadding from './SafeBottomPadding'
 import Title from './Title'
 import VocabularyListItem from './VocabularyListItem'
 
@@ -33,6 +34,7 @@ const VocabularyList = ({ vocabularyItems, onItemPress, title }: VocabularyListS
             }`}
           />
         }
+        ListFooterComponent={<SafeBottomPadding />}
         data={vocabularyItems}
         renderItem={renderItem}
         keyExtractor={item => `${item.id}`}

--- a/src/routes/ProfessionSelectionScreen.tsx
+++ b/src/routes/ProfessionSelectionScreen.tsx
@@ -1,13 +1,14 @@
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
-import { FlatList } from 'react-native'
+import { FlatList, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { CheckCircleIconGreen } from '../../assets/images'
 import Button from '../components/Button'
 import DisciplineListItem from '../components/DisciplineListItem'
 import RouteWrapper from '../components/RouteWrapper'
+import SafeBottomPadding from '../components/SafeBottomPadding'
 import ServerResponseHandler from '../components/ServerResponseHandler'
 import Title from '../components/Title'
 import { BUTTONS_THEME } from '../constants/data'
@@ -24,8 +25,8 @@ const List = styled.FlatList`
 ` as unknown as typeof FlatList
 
 const ButtonContainer = styled.View`
-  padding: ${props => props.theme.spacings.md} 0;
-  margin: 0 auto 0;
+  padding: ${props => props.theme.spacings.md};
+  margin: 0 auto ${props => props.theme.spacings.md};
 `
 
 const IconContainer = styled.View`
@@ -98,15 +99,18 @@ const ProfessionSelectionScreen = ({ route, navigation }: ProfessionSelectionScr
           contentContainerStyle={{ flexGrow: 1 }}
           ListHeaderComponent={<Title title={discipline.title} description={childrenDescription(discipline)} />}
           ListFooterComponent={
-            !isSelectionMade ? (
-              <ButtonContainer>
-                <Button
-                  onPress={navigateToHomeScreen}
-                  label={getLabels().scopeSelection.skipSelection}
-                  buttonTheme={BUTTONS_THEME.contained}
-                />
-              </ButtonContainer>
-            ) : null
+            <View>
+              {!isSelectionMade && (
+                <ButtonContainer>
+                  <Button
+                    onPress={navigateToHomeScreen}
+                    label={getLabels().scopeSelection.skipSelection}
+                    buttonTheme={BUTTONS_THEME.contained}
+                  />
+                </ButtonContainer>
+              )}
+              <SafeBottomPadding />
+            </View>
           }
           ListFooterComponentStyle={{ flex: 1, justifyContent: 'flex-end' }}
           data={disciplines}

--- a/src/routes/scope-selection/ScopeSelectionScreen.tsx
+++ b/src/routes/scope-selection/ScopeSelectionScreen.tsx
@@ -7,6 +7,7 @@ import styled, { useTheme } from 'styled-components/native'
 import Button from '../../components/Button'
 import Header from '../../components/Header'
 import RouteWrapper from '../../components/RouteWrapper'
+import SafeBottomPadding from '../../components/SafeBottomPadding'
 import { ContentSecondary } from '../../components/text/Content'
 import { Heading } from '../../components/text/Heading'
 import { BUTTONS_THEME } from '../../constants/data'
@@ -95,6 +96,7 @@ const ScopeSelectionScreen = ({ navigation, route }: IntroScreenProps): JSX.Elem
             />
           </ButtonContainer>
         )}
+        <SafeBottomPadding />
       </ScrollView>
     </RouteWrapper>
   )


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This pr fixes some problems caused by #1105 where the content starts to overlap the system navigation bar on android.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- For each screen not part of the bottom tab navigator, add some bottom padding manually

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
The modified screens should have some more padding, on no screen should content overlap with the android navigation bar

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1106 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
