### PR TITLE
1106: Android content overlay

### DIFF
--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react'
 import { Platform, StatusBar } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
 import theme from '../constants/theme'
@@ -10,11 +11,20 @@ type RouteWrapperProps = {
   children: ReactNode
   /** Separate bgColor for notches only works for ios */
   bottomBackgroundColor?: string
+  shouldSetBottomInset?: boolean
+  shouldSetTopInset?: boolean
 }
 
-const Container = styled.SafeAreaView<{ backgroundColor: string; shouldTakeSpace: boolean }>`
+const Container = styled.SafeAreaView<{
+  backgroundColor: string
+  shouldTakeSpace: boolean
+  bottomInset?: number
+  topInset?: number
+}>`
   background-color: ${props => props.backgroundColor};
   flex: ${props => (props.shouldTakeSpace ? '1' : '0')};
+  ${props => (props.topInset ? `padding-top: ${props.topInset}px` : undefined)};
+  ${props => (props.bottomInset ? `padding-bottom: ${props.bottomInset}px` : undefined)};
 `
 
 const RouteWrapper = ({
@@ -22,20 +32,28 @@ const RouteWrapper = ({
   lightStatusBarContent = false,
   children,
   bottomBackgroundColor,
-}: RouteWrapperProps): ReactElement => (
-  <>
-    <Container backgroundColor={backgroundColor} shouldTakeSpace>
-      <StatusBar
+  shouldSetBottomInset = false,
+  shouldSetTopInset = false,
+}: RouteWrapperProps): ReactElement => {
+  const insets = useSafeAreaInsets()
+  return (
+    <>
+      <Container
         backgroundColor={backgroundColor}
-        barStyle={lightStatusBarContent ? 'light-content' : 'dark-content'}
-      />
-      {children}
-    </Container>
-    {/* For iOS a separate container is needed to overwrite the color of the bottom notch */}
-    {bottomBackgroundColor && Platform.OS === 'ios' ? (
-      <Container shouldTakeSpace={false} backgroundColor={bottomBackgroundColor} testID='hiddenContainer' />
-    ) : null}
-  </>
-)
-
+        shouldTakeSpace
+        bottomInset={shouldSetBottomInset ? insets.bottom : undefined}
+        topInset={shouldSetTopInset ? insets.top : undefined}>
+        <StatusBar
+          backgroundColor={backgroundColor}
+          barStyle={lightStatusBarContent ? 'light-content' : 'dark-content'}
+        />
+        {children}
+      </Container>
+      {/* For iOS a separate container is needed to overwrite the color of the bottom notch */}
+      {bottomBackgroundColor && Platform.OS === 'ios' ? (
+        <Container shouldTakeSpace={false} backgroundColor={bottomBackgroundColor} testID='hiddenContainer' />
+      ) : null}
+    </>
+  )
+}
 export default RouteWrapper

--- a/src/routes/OverlayMenuScreen.tsx
+++ b/src/routes/OverlayMenuScreen.tsx
@@ -2,6 +2,7 @@ import { CardStyleInterpolators, StackNavigationProp } from '@react-navigation/s
 import { StackNavigationOptions } from '@react-navigation/stack/lib/typescript/src/types'
 import React, { ReactElement } from 'react'
 import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
 import { CloseIconWhite } from '../../assets/images'
@@ -34,9 +35,10 @@ const DismissArea = styled.Pressable`
   flex: 1;
 `
 
-const Sidebar = styled.SafeAreaView`
+const Sidebar = styled.SafeAreaView<{ paddingTop: number }>`
   height: 100%;
   width: 80%;
+  padding-top: ${props => props.paddingTop}px;
   align-self: flex-end;
   background-color: ${props => props.theme.colors.primary};
 `
@@ -59,35 +61,39 @@ type OverlayProps = {
   navigation: StackNavigationProp<RoutesParams, keyof RoutesParams>
 }
 
-const OverlayMenu = ({ navigation }: OverlayProps): ReactElement => (
-  <Container>
-    <DismissArea onPress={navigation.goBack} style={{ height: '100%', flex: 1 }} />
-    <Sidebar>
-      <Icon onPress={navigation.goBack}>
-        <CloseIconWhite testID='close-icon-white' />
-      </Icon>
-      <OverlayMenuItem
-        title={getLabels().general.header.manageSelection}
-        onPress={() => navigation.navigate('ManageSelection')}
-      />
-      <OverlayMenuSeparator />
-      <OverlayMenuItem
-        isSubItem
-        title={getLabels().general.header.sponsors}
-        onPress={() => navigation.navigate('Sponsors')}
-      />
-      <OverlayMenuItem
-        isSubItem
-        title={getLabels().general.header.settings}
-        onPress={() => navigation.navigate('Settings')}
-      />
-      <OverlayMenuItem
-        isSubItem
-        title={getLabels().general.header.impressum}
-        onPress={() => navigation.navigate('Imprint')}
-      />
-    </Sidebar>
-  </Container>
-)
+const OverlayMenu = ({ navigation }: OverlayProps): ReactElement => {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <Container>
+      <DismissArea onPress={navigation.goBack} style={{ height: '100%', flex: 1 }} />
+      <Sidebar paddingTop={insets.top}>
+        <Icon onPress={navigation.goBack}>
+          <CloseIconWhite testID='close-icon-white' />
+        </Icon>
+        <OverlayMenuItem
+          title={getLabels().general.header.manageSelection}
+          onPress={() => navigation.navigate('ManageSelection')}
+        />
+        <OverlayMenuSeparator />
+        <OverlayMenuItem
+          isSubItem
+          title={getLabels().general.header.sponsors}
+          onPress={() => navigation.navigate('Sponsors')}
+        />
+        <OverlayMenuItem
+          isSubItem
+          title={getLabels().general.header.settings}
+          onPress={() => navigation.navigate('Settings')}
+        />
+        <OverlayMenuItem
+          isSubItem
+          title={getLabels().general.header.impressum}
+          onPress={() => navigation.navigate('Imprint')}
+        />
+      </Sidebar>
+    </Container>
+  )
+}
 
 export default OverlayMenu

--- a/src/routes/ProfessionSelectionScreen.tsx
+++ b/src/routes/ProfessionSelectionScreen.tsx
@@ -92,7 +92,7 @@ const ProfessionSelectionScreen = ({ route, navigation }: ProfessionSelectionScr
   }
 
   return (
-    <RouteWrapper>
+    <RouteWrapper shouldSetBottomInset>
       <ServerResponseHandler error={error} loading={loading} refresh={refresh}>
         <List
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/routes/VocabularyListScreen.tsx
+++ b/src/routes/VocabularyListScreen.tsx
@@ -30,7 +30,7 @@ const VocabularyListScreen = ({ route, navigation }: VocabularyListScreenProps):
     navigation.navigate('VocabularyDetailExercise', { ...route.params, vocabularyItemIndex: index })
 
   return (
-    <RouteWrapper>
+    <RouteWrapper shouldSetBottomInset>
       <ExerciseHeader
         navigation={navigation}
         confirmClose={false}

--- a/src/routes/home/HomeScreen.tsx
+++ b/src/routes/home/HomeScreen.tsx
@@ -79,7 +79,7 @@ const HomeScreen = ({ navigation }: HomeScreenProps): JSX.Element => {
   ))
 
   return (
-    <RouteWrapper backgroundColor={theme.colors.primary} lightStatusBarContent>
+    <RouteWrapper backgroundColor={theme.colors.primary} lightStatusBarContent shouldSetTopInset>
       <Root contentContainerStyle={{ flexGrow: 1, justifyContent: 'space-between' }}>
         <View>
           <HomeScreenHeader navigation={navigation} />

--- a/src/routes/scope-selection/ScopeSelectionScreen.tsx
+++ b/src/routes/scope-selection/ScopeSelectionScreen.tsx
@@ -64,7 +64,8 @@ const ScopeSelectionScreen = ({ navigation, route }: IntroScreenProps): JSX.Elem
   return (
     <RouteWrapper
       backgroundColor={initialSelection ? theme.colors.primary : theme.colors.background}
-      lightStatusBarContent={initialSelection}>
+      lightStatusBarContent={initialSelection}
+      shouldSetBottomInset>
       <ScrollView>
         {initialSelection && <Header />}
 


### PR DESCRIPTION
### Short Description

With android 15 in some parts, `SafeArea` will get handled differently and we need to define some paddings for particular screens to avoid overlapping

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add `shouldSetBottomInset` and `shouldSetTopInset` to `RouteWrapper`
- use the inset on routes if needed

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing

- start application with Android Bottom Navigation instead of gesture navigation
- Check `HomeScreen`, `Scope`, `ProfessionSelection` and `VocabularyList` for content overlapping or other glitches
- Test with android and ios

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1106

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
