### PR TITLE
Fix horizontal overflow on edit mode in user vocabulary list

### DIFF
--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -21,7 +21,6 @@ const Container = styled(GenericListItemContainer)<{
   feedback: EXERCISE_FEEDBACK
 }>`
   min-height: ${hp('12%')}px;
-  width: 100%;
   justify-content: center;
   flex-direction: column;
   border-top-width: 1px;

--- a/src/routes/user-vocabulary-list/components/ListItem.tsx
+++ b/src/routes/user-vocabulary-list/components/ListItem.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react'
-import { widthPercentageToDP as wp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
 import { PenIcon, TrashIcon } from '../../../../assets/images'
@@ -12,7 +11,7 @@ const Container = styled.View`
 `
 
 const VocabularyListItemContainer = styled.View`
-  min-width: ${wp('90%')}px;
+  flex: 1;
 `
 
 const IconContainer = styled.View`


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This pr fixes a horizontal overflow when in edit mode on the user vocabulary list

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Don't force 100% width, instead just use auto
- Allow flex

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
List items should still work

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #978 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
