### PR TITLE
Remove unused `READ_EXTERNAL_STORAGE` permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
       android:name=".MainApplication"
@@ -12,8 +11,7 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme"
-      android:supportsRtl="false"
-      android:requestLegacyExternalStorage="true">
+      android:supportsRtl="false">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This permission was used before for `react-native-image-crop-picker`, but not anymore (see comments of #1059 )

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the permission

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test creating new vocabulary and adding images and sound to it. I tested it on emulated android api 35 and api 26

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1059 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
