### PR TITLE
Fix bug on setup when the app cannot connect to the lunes server

### DIFF
--- a/release-notes/unreleased/1132-cannot-finish-setup-on-network-error.yml
+++ b/release-notes/unreleased/1132-cannot-finish-setup-on-network-error.yml
@@ -1,0 +1,6 @@
+issue_key: 1132
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Ein potentieller Fehler bei der Einrichtung wurde behoben.

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -32,7 +32,6 @@ export const ErrorText = styled(Content)<{ centered?: boolean }>`
 `
 const NetworkErrorWrapper = styled.View`
   background-color: ${prop => prop.theme.colors.background};
-  height: 100%;
   align-items: center;
 `
 const IconStyle = styled.View`
@@ -65,7 +64,7 @@ const ErrorMessage = ({ error, refresh, contained }: ErrorMessageProps): JSX.Ele
 
   return (
     <NetworkErrorWrapper>
-      <RoundedBackground color={theme.colors.lightGreyBackground} height='55%'>
+      <RoundedBackground color={theme.colors.lightGreyBackground}>
         <Container>
           {error.message === NetworkError && (
             <IconStyle>

--- a/src/components/RoundedBackground.tsx
+++ b/src/components/RoundedBackground.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 const RoundedBackground = styled.View<{ color?: string; height?: string }>`
   width: 140%;
-  height: ${props => props.height ?? '50%'};
+  height: ${props => props.height};
   background-color: ${props => props.color ?? props.theme.colors.primary};
   border-bottom-left-radius: ${hp('60%')}px;
   border-bottom-right-radius: ${hp('60%')}px;


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->Reduces the height of the error message, so that the 'retry' and 'skip' buttons are not obstructed.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove hardcoded height constraints and just let it calculate automatically

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
When I tried to test this on ios, the app just crashed. At the reviewer, if you have a physical ios device, could you please check whether that is just a simulator bug or an actual problem?

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1132 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
