### PR TITLE
Upload aab to google play instead of apk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,12 +266,18 @@ jobs:
                 command: mkdir -p attached_workspace && mv app/build/outputs/apk/release/app-release.apk attached_workspace/app-release.apk
                 name: Move apk
                 working_directory: android
+            - run:
+                command: mv app/build/outputs/bundle/release/app-release.aab attached_workspace/app-release.aab
+                name: Move aab
             - persist_to_workspace:
                 paths:
                     - app-release.apk
+                    - app-release.aab
                 root: android/attached_workspace
             - store_artifacts:
                 path: android/attached_workspace/app-release.apk
+            - store_artifacts:
+                path: android/attached_workspace/app-release.aab
             - run:
                 command: echo "[lunes.apk](https://output.circle-artifacts.com/output/job/$CIRCLE_WORKFLOW_JOB_ID/artifacts/0/android/attached_workspace/app-release.apk)" >> lunes-apk-url
                 name: Persist artifact url

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -53,12 +53,18 @@ steps:
       name: Move apk
       command: mkdir -p attached_workspace && mv app/build/outputs/apk/release/app-release.apk attached_workspace/app-release.apk
       working_directory: android
+  - run:
+      name: Move aab
+      command: mv app/build/outputs/bundle/release/app-release.aab attached_workspace/app-release.aab
   - persist_to_workspace:
       root: android/attached_workspace
       paths:
         - app-release.apk
+        - app-release.aab
   - store_artifacts:
       path: android/attached_workspace/app-release.apk
+  - store_artifacts:
+      path: android/attached_workspace/app-release.aab
   - run:
       name: Persist artifact url
       command: echo "[lunes.apk](https://output.circle-artifacts.com/output/job/$CIRCLE_WORKFLOW_JOB_ID/artifacts/0/android/attached_workspace/app-release.apk)" >> lunes-apk-url

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -76,7 +76,7 @@ platform :android do
         end
 
         gradle(
-          task: "assembleRelease",
+          tasks: ["assembleRelease", "bundleRelease"],
           properties: {
               :VERSION_CODE => version_code,
               :VERSION_NAME => version_name,
@@ -117,7 +117,7 @@ platform :android do
             skip_upload_screenshots: true,
             skip_upload_metadata: true,
             release_status: "completed",
-            apk: "#{ENV['HOME']}/attached_workspace/app-release.apk",
+            aab: "#{ENV['HOME']}/attached_workspace/app-release.aab",
             json_key_data: ENV["GOOGLE_SERVICE_ACCOUNT_JSON"]
         )
     end
@@ -159,6 +159,7 @@ platform :android do
       skip_upload_screenshots: true,
       skip_upload_metadata: true,
       skip_upload_apk: true,
+      skip_upload_aab: true,
       release_status: "completed",
       json_key_data: ENV["GOOGLE_SERVICE_ACCOUNT_JSON"]
     )

--- a/release-notes/unreleased/1115-reduce-app-size.yml
+++ b/release-notes/unreleased/1115-reduce-app-size.yml
@@ -1,0 +1,6 @@
+issue_key:
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Die App-Größe wurde reduziert


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This should reduce the app size.
We keep compiling apks as well, since they are more useful for debugging and as release assets.
Related: https://github.com/digitalfabrik/integreat-app/pull/2977/

The current compressed download size is 44.3MB according to google play, lets see if that improves at the next beta release with this pr (Google estimates -23MB if we use aabs)


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Generate an app bundle as well
- Upload the app bundle to google play, instead of the apk
- Keep the apks as release assets for github releases and mattermost notifications

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Probably slower ci times

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

We can only really test this when creating the next beta release

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1115 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
