### PR TITLE
Remove suggest remove alternative word button

### DIFF
--- a/release-notes/unreleased/1149-remove-suggest-alternative-word-button.yml
+++ b/release-notes/unreleased/1149-remove-suggest-alternative-word-button.yml
@@ -1,0 +1,6 @@
+issue_key: 1149
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Die Schaltfläche 'anderes Wort vorschlagen' wurde entfernt

--- a/src/routes/vocabulary-detail-exercise/components/AlternativeWordsSection.tsx
+++ b/src/routes/vocabulary-detail-exercise/components/AlternativeWordsSection.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
-import { ArrowRightIcon, CrystalBallIcon } from '../../../../assets/images'
-import FeedbackModal from '../../../components/FeedbackModal'
-import { ContentSecondary, ContentTextBold } from '../../../components/text/Content'
-import { FeedbackType } from '../../../constants/data'
+import { CrystalBallIcon } from '../../../../assets/images'
+import { ContentSecondary } from '../../../components/text/Content'
 import { VocabularyItem } from '../../../constants/endpoints'
-import theme from '../../../constants/theme'
 import { getLabels } from '../../../services/helpers'
 
 const Heading = styled(ContentSecondary)`
@@ -28,48 +25,21 @@ const Content = styled.View`
   padding: 0 ${props => props.theme.spacings.sm};
 `
 
-const SuggestionPressable = styled.Pressable`
-  flex-direction: row;
-  align-items: center;
-  padding: ${props => props.theme.spacings.xs} 0 ${props => props.theme.spacings.xxl};
-`
-
-const Label = styled(ContentTextBold)`
-  text-transform: uppercase;
-`
-
 type AlternativeWordsSectionProps = {
   vocabularyItem: VocabularyItem
 }
 
-const AlternativeWordsSection = ({ vocabularyItem }: AlternativeWordsSectionProps): JSX.Element => {
-  const [isFeedbackModalVisible, setIsFeedbackModalVisible] = useState(false)
-  return (
+const AlternativeWordsSection = ({ vocabularyItem }: AlternativeWordsSectionProps): JSX.Element | null =>
+  vocabularyItem.alternatives.length > 0 ? (
     <Root>
       <CrystalBallIcon width={hp('3.5%')} height={hp('3.5%')} />
       <Content>
-        {vocabularyItem.alternatives.length > 0 && (
-          <>
-            <Heading>{getLabels().exercises.vocabularyList.alternativeWords}</Heading>
-            <AlternativeWords>
-              {vocabularyItem.alternatives.map(value => `${value.article.value} ${value.word}`).join(', ')}
-            </AlternativeWords>
-          </>
-        )}
-
-        <SuggestionPressable onPress={() => setIsFeedbackModalVisible(true)}>
-          <Label>{getLabels().exercises.vocabularyList.suggestAlternative}</Label>
-          <ArrowRightIcon fill={theme.colors.black} width={hp('3%')} height={hp('3%')} />
-        </SuggestionPressable>
+        <Heading>{getLabels().exercises.vocabularyList.alternativeWords}</Heading>
+        <AlternativeWords>
+          {vocabularyItem.alternatives.map(value => `${value.article.value} ${value.word}`).join(', ')}
+        </AlternativeWords>
       </Content>
-      <FeedbackModal
-        visible={isFeedbackModalVisible}
-        onClose={() => setIsFeedbackModalVisible(false)}
-        feedbackType={FeedbackType.vocabularyItem}
-        feedbackForId={vocabularyItem.id}
-      />
     </Root>
-  )
-}
+  ) : null
 
 export default AlternativeWordsSection

--- a/src/routes/vocabulary-detail-exercise/components/__tests__/AlternativeWords.spec.tsx
+++ b/src/routes/vocabulary-detail-exercise/components/__tests__/AlternativeWords.spec.tsx
@@ -16,12 +16,10 @@ describe('AlternativeWords', () => {
         `${vocabularyItems[0].alternatives[0].article.value} ${vocabularyItems[0].alternatives[0].word}, ${vocabularyItems[0].alternatives[1].article.value} ${vocabularyItems[0].alternatives[1].word}`,
       ),
     ).toBeDefined()
-    expect(getByText(getLabels().exercises.vocabularyList.suggestAlternative)).toBeDefined()
   })
 
   it('should not display alternative words, if word has none', () => {
-    const { getByText, queryByText } = render(<AlternativeWordsSection vocabularyItem={vocabularyItems[1]} />)
+    const { queryByText } = render(<AlternativeWordsSection vocabularyItem={vocabularyItems[1]} />)
     expect(queryByText(getLabels().exercises.vocabularyList.alternativeWords)).toBeNull()
-    expect(getByText(getLabels().exercises.vocabularyList.suggestAlternative)).toBeDefined()
   })
 })


### PR DESCRIPTION




### Short Description
Alternative words can still be suggested via the context menu, but the button was too confusing for users.
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Don't show the button anymore in wordlists
- Completely hide the `AlternativeWordSection` if no alternatives exist

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that wordlists still work

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1149 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
