### PR TITLE
Fix non unique key in dictionary list item

### DIFF
--- a/src/routes/dictionary/components/DictionaryItem.tsx
+++ b/src/routes/dictionary/components/DictionaryItem.tsx
@@ -22,7 +22,7 @@ type DictionaryItemProps = {
 
 const DictionaryItem = ({ vocabularyItem, navigateToDetail, showAlternatives }: DictionaryItemProps): ReactElement => (
   <VocabularyListItem
-    key={vocabularyItem.id}
+    key={JSON.stringify({ id: vocabularyItem.id, type: vocabularyItem.type })}
     vocabularyItem={vocabularyItem}
     onPress={() => navigateToDetail(vocabularyItem)}>
     <>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Small bugfix where the key of a dictionary list item was not always unique.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Also include the type of the vocabulary items in the key, to guarantee its uniqueness

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1181

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
