### PR TITLE
Remove custom disciplines

### DIFF
--- a/release-notes/unreleased/1186-remove-custom-disciplines.yml
+++ b/release-notes/unreleased/1186-remove-custom-disciplines.yml
@@ -1,0 +1,6 @@
+issue_key: 1186
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Eigene Lernbereiche wurden entfernt

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -4,7 +4,6 @@ import { useTheme } from 'styled-components/native'
 
 import DisciplineSelectionScreen from '../routes/DisciplineSelectionScreen'
 import ImprintScreen from '../routes/ImprintScreen'
-import AddCustomDisciplineScreen from '../routes/add-custom-discipline/AddCustomDisciplineScreen'
 import StandardExercisesScreen from '../routes/exercises/StandardExercisesScreen'
 import HomeScreen from '../routes/home/HomeScreen'
 import ManageSelectionsScreen from '../routes/manage-selections/ManageSelectionsScreen'
@@ -38,11 +37,6 @@ const HomeStackNavigator = (): JSX.Element | null => {
         name='StandardExercises'
         component={StandardExercisesScreen}
         options={({ navigation, route }) => options(route.params.discipline.parentTitle ?? overview, navigation)}
-      />
-      <Stack.Screen
-        name='AddCustomDiscipline'
-        component={AddCustomDisciplineScreen}
-        options={({ navigation }) => options(overview, navigation)}
       />
       <Stack.Screen
         name='Imprint'

--- a/src/routes/home/HomeScreen.tsx
+++ b/src/routes/home/HomeScreen.tsx
@@ -9,10 +9,8 @@ import { ContentSecondary } from '../../components/text/Content'
 import { Heading } from '../../components/text/Heading'
 import { EXERCISES, NextExerciseData } from '../../constants/data'
 import { Discipline } from '../../constants/endpoints'
-import useStorage from '../../hooks/useStorage'
 import { RoutesParams } from '../../navigation/NavigationTypes'
 import { getLabels } from '../../services/helpers'
-import AddCustomDisciplineCard from './components/AddCustomDiscipline'
 import HomeFooter from './components/HomeFooter'
 import HomeScreenHeader from './components/HomeScreenHeader'
 import SelectedProfessions from './components/SelectedProfessions'
@@ -36,12 +34,6 @@ type HomeScreenProps = {
 
 const HomeScreen = ({ navigation }: HomeScreenProps): JSX.Element => {
   const theme = useTheme()
-  const [customDisciplines] = useStorage('customDisciplines')
-  const hasNoCustomDisciplines = customDisciplines.length === 0
-
-  const navigateToAddCustomDisciplineScreen = (): void => {
-    navigation.navigate('AddCustomDiscipline')
-  }
 
   const navigateToManageSelection = (): void => {
     navigation.navigate('ManageSelection')
@@ -81,7 +73,6 @@ const HomeScreen = ({ navigation }: HomeScreenProps): JSX.Element => {
             navigateToManageSelection={navigateToManageSelection}
             navigateToProfessionSelection={navigateToProfessionSelection}
           />
-          {hasNoCustomDisciplines && <AddCustomDisciplineCard navigate={navigateToAddCustomDisciplineScreen} />}
         </View>
         <HomeFooter />
       </Root>

--- a/src/routes/home/__tests__/HomeScreen.spec.tsx
+++ b/src/routes/home/__tests__/HomeScreen.spec.tsx
@@ -1,15 +1,11 @@
-import { fireEvent } from '@testing-library/react-native'
 import { mocked } from 'jest-mock'
 import React from 'react'
 
 import { useLoadDiscipline } from '../../../hooks/useLoadDiscipline'
-import { useLoadDisciplines } from '../../../hooks/useLoadDisciplines'
 import useReadProgress from '../../../hooks/useReadProgress'
 import { StorageCache } from '../../../services/Storage'
-import { getLabels } from '../../../services/helpers'
 import createNavigationMock from '../../../testing/createNavigationPropMock'
 import { getReturnOf } from '../../../testing/helper'
-import { mockCustomDiscipline } from '../../../testing/mockCustomDiscipline'
 import { mockDisciplines } from '../../../testing/mockDiscipline'
 import { renderWithStorageCache } from '../../../testing/render'
 import HomeScreen from '../HomeScreen'
@@ -52,27 +48,5 @@ describe('HomeScreen', () => {
     expect(firstDiscipline).toBeDefined()
     expect(secondDiscipline).toBeDefined()
     expect(thirdDiscipline).toBeDefined()
-  })
-
-  it('should render custom discipline', async () => {
-    await storageCache.setItem('customDisciplines', ['test'])
-    mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf(mockDisciplines()))
-    mocked(useLoadDiscipline).mockReturnValueOnce(getReturnOf(mockCustomDiscipline))
-
-    const { getByText } = renderWithStorageCache(storageCache, <HomeScreen navigation={navigation} />)
-    expect(getByText('Custom Discipline')).toBeDefined()
-    expect(getByText(getLabels().home.start)).toBeDefined()
-  })
-
-  it('should show suggestion to add custom discipline', () => {
-    mocked(useLoadDisciplines).mockReturnValueOnce(getReturnOf([]))
-
-    const { getByText } = renderWithStorageCache(storageCache, <HomeScreen navigation={navigation} />)
-    const addCustomDiscipline = getByText(getLabels().home.addCustomDiscipline)
-    expect(addCustomDiscipline).toBeDefined()
-
-    fireEvent.press(addCustomDiscipline)
-
-    expect(navigation.navigate).toHaveBeenCalledWith('AddCustomDiscipline')
   })
 })

--- a/src/routes/home/components/SelectedProfessions.tsx
+++ b/src/routes/home/components/SelectedProfessions.tsx
@@ -53,12 +53,7 @@ type SelectedProfessionsProps = {
 
 const useAllProfessions = (): RequestParams[] => {
   const [selectedProfessions] = useStorage('selectedProfessions')
-  const [customDisciplines] = useStorage('customDisciplines')
-
-  const localProfessionParams = selectedProfessions?.map(id => ({ disciplineId: id })) ?? []
-  const customProfessionParams = customDisciplines.map(id => ({ apiKey: id }))
-
-  return [...localProfessionParams, ...customProfessionParams]
+  return selectedProfessions?.map(id => ({ disciplineId: id })) ?? []
 }
 
 const SelectedProfessions = ({

--- a/src/routes/manage-selections/ManageSelectionsScreen.tsx
+++ b/src/routes/manage-selections/ManageSelectionsScreen.tsx
@@ -11,7 +11,7 @@ import useStorage, { useStorageCache } from '../../hooks/useStorage'
 import { RoutesParams } from '../../navigation/NavigationTypes'
 import { getLabels } from '../../services/helpers'
 import { reportError } from '../../services/sentry'
-import { removeCustomDiscipline, removeSelectedProfession } from '../../services/storageUtils'
+import { removeSelectedProfession } from '../../services/storageUtils'
 import SelectionItem from './components/SelectionItem'
 
 const Root = styled.ScrollView`
@@ -39,7 +39,6 @@ type ManageSelectionScreenProps = {
 const ManageSelectionsScreen = ({ navigation }: ManageSelectionScreenProps): ReactElement => {
   const storageCache = useStorageCache()
   const [selectedProfessions] = useStorage('selectedProfessions')
-  const [customDisciplines] = useStorage('customDisciplines')
 
   const professionItems = selectedProfessions?.map(id => {
     const unselectProfessionAndRefresh = () => {
@@ -48,19 +47,8 @@ const ManageSelectionsScreen = ({ navigation }: ManageSelectionScreenProps): Rea
     return <SelectionItem key={id} identifier={{ disciplineId: id }} deleteItem={unselectProfessionAndRefresh} />
   })
 
-  const customDisciplineItems = customDisciplines.map(apiKey => {
-    const deleteCustomDisciplineAndRefresh = async () => {
-      await removeCustomDiscipline(storageCache, apiKey)
-    }
-    return <SelectionItem key={apiKey} identifier={{ apiKey }} deleteItem={deleteCustomDisciplineAndRefresh} />
-  })
-
   const navigateToProfessionSelection = () => {
     navigation.navigate('ScopeSelection', { initialSelection: false })
-  }
-
-  const navigateToAddCustomDiscipline = () => {
-    navigation.navigate('AddCustomDiscipline')
   }
 
   return (
@@ -71,16 +59,6 @@ const ManageSelectionsScreen = ({ navigation }: ManageSelectionScreenProps): Rea
         <HorizontalLine />
         {professionItems}
         <AddElement onPress={navigateToProfessionSelection} label={getLabels().manageSelection.addProfession} />
-
-        <SectionHeading>{getLabels().manageSelection.yourCustomDisciplines}</SectionHeading>
-        <HorizontalLine />
-        {customDisciplineItems}
-
-        <AddElement
-          onPress={navigateToAddCustomDiscipline}
-          label={getLabels().home.addCustomDiscipline}
-          explanation={getLabels().manageSelection.descriptionAddCustomDiscipline}
-        />
         <Padding />
       </Root>
     </RouteWrapper>

--- a/src/routes/manage-selections/__tests__/ManageSelectionsScreen.spec.tsx
+++ b/src/routes/manage-selections/__tests__/ManageSelectionsScreen.spec.tsx
@@ -8,7 +8,6 @@ import { getLabels } from '../../../services/helpers'
 import { pushSelectedProfession } from '../../../services/storageUtils'
 import createNavigationMock from '../../../testing/createNavigationPropMock'
 import { getReturnOf } from '../../../testing/helper'
-import { mockCustomDiscipline } from '../../../testing/mockCustomDiscipline'
 import { mockDisciplines } from '../../../testing/mockDiscipline'
 import { renderWithStorageCache } from '../../../testing/render'
 import ManageSelectionsScreen from '../ManageSelectionsScreen'
@@ -40,29 +39,6 @@ describe('ManageSelectionsScreen', () => {
       const selectedProfessions = storageCache.getItem('selectedProfessions')
       expect(selectedProfessions).toEqual([])
     })
-  })
-
-  it('should show and delete custom disciplines', async () => {
-    await storageCache.setItem('customDisciplines', [mockCustomDiscipline.apiKey])
-    mocked(useLoadDiscipline).mockReturnValueOnce(getReturnOf(mockCustomDiscipline))
-
-    const { getByText, getByTestId } = renderScreen()
-    expect(getByText(mockCustomDiscipline.title)).toBeDefined()
-    const deleteIcon = getByTestId('delete-icon')
-    fireEvent.press(deleteIcon)
-    const confirmButton = getByText(getLabels().manageSelection.deleteModal.confirm)
-    fireEvent.press(confirmButton)
-    await waitFor(() => {
-      const customDisciplines = storageCache.getItem('customDisciplines')
-      expect(customDisciplines).toEqual([])
-    })
-  })
-
-  it('should navigate to add custom discipline', () => {
-    const { getByText } = renderScreen()
-    const addCustomDisciplineText = getByText(getLabels().home.addCustomDiscipline)
-    fireEvent.press(addCustomDisciplineText)
-    expect(navigation.navigate).toHaveBeenCalledWith('AddCustomDiscipline')
   })
 
   it('should navigate to select another profession', () => {

--- a/src/services/Storage.tsx
+++ b/src/services/Storage.tsx
@@ -21,6 +21,8 @@ export type Storage = {
   isDevModeEnabled: boolean
   progress: Progress
   cmsUrlOverwrite: CMS | null
+  // Unused, old feature
+  // TODO: fully delete if we decide that this is not needed anymore
   customDisciplines: string[]
   userVocabulary: UserVocabularyItem[]
   nextUserVocabularyId: number


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The new CMS does not support custom disciplines anymore, so this feature needs to be removed in the migration.
We decided to leave most of the implementation in tact and decide at the next conference whether we want to fully get rid of it or re-add it.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove all user facing functionality of custom disciplines, but leave most of the implementation

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1186

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
