### PR TITLE
Migrate sponsors to new api

### DIFF
--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -1,11 +1,5 @@
 import { Article, VocabularyItemType } from './data'
 
-export type Sponsor = {
-  name: string
-  logo?: string
-  url?: string
-}
-
 export type Discipline = {
   id: number
   title: string

--- a/src/hooks/useGetAllSponsors.ts
+++ b/src/hooks/useGetAllSponsors.ts
@@ -1,9 +1,0 @@
-import { ENDPOINTS, Sponsor } from '../constants/endpoints'
-import { getFromEndpoint } from '../services/axios'
-import { Return, useLoadAsync } from './useLoadAsync'
-
-export const getAllSponsors = async (): Promise<Sponsor[]> => getFromEndpoint<Sponsor[]>(ENDPOINTS.sponsors)
-
-const useGetAllSponsors = (): Return<Sponsor[]> => useLoadAsync(getAllSponsors, {})
-
-export default useGetAllSponsors

--- a/src/hooks/useLoadSponsors.ts
+++ b/src/hooks/useLoadSponsors.ts
@@ -1,0 +1,7 @@
+import Sponsor from '../models/sponsor'
+import { getSponsors } from '../services/CmsApi'
+import { Return, useLoadAsync } from './useLoadAsync'
+
+const useLoadSponsors = (): Return<Sponsor[]> => useLoadAsync(getSponsors, {})
+
+export default useLoadSponsors

--- a/src/models/sponsor.ts
+++ b/src/models/sponsor.ts
@@ -1,0 +1,7 @@
+type Sponsor = {
+  name: string
+  logo: string | null
+  url: string | null
+}
+
+export default Sponsor

--- a/src/routes/sponsors/SponsorsScreen.tsx
+++ b/src/routes/sponsors/SponsorsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react'
+import React, { ReactElement } from 'react'
 import { FlatList } from 'react-native'
 import { heightPercentageToDP as hp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
@@ -8,8 +8,8 @@ import ServerResponseHandler from '../../components/ServerResponseHandler'
 import { ContentSecondary } from '../../components/text/Content'
 import { Heading } from '../../components/text/Heading'
 import { Subheading } from '../../components/text/Subheading'
-import { Sponsor } from '../../constants/endpoints'
-import useGetAllSponsors from '../../hooks/useGetAllSponsors'
+import useLoadSponsors from '../../hooks/useLoadSponsors'
+import Sponsor from '../../models/sponsor'
 import { getLabels } from '../../services/helpers'
 import { openExternalUrl } from '../../services/url'
 
@@ -53,8 +53,7 @@ const ItemContainer = styled.TouchableOpacity`
 `
 
 const SponsorsScreen = (): ReactElement => {
-  const { data, loading, error, refresh } = useGetAllSponsors()
-  useMemo(() => (data ? data.sort((a, b) => a.name.localeCompare(b.name)) : undefined), [data])
+  const { data, loading, error, refresh } = useLoadSponsors()
 
   const renderListItem = ({ item }: { item: Sponsor }): ReactElement => (
     <ItemContainer onPress={() => (item.url ? openExternalUrl(item.url) : null)}>

--- a/src/routes/sponsors/__tests__/SponsorsScreen.spec.tsx
+++ b/src/routes/sponsors/__tests__/SponsorsScreen.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/react-native'
 import React from 'react'
 
-import { Sponsor } from '../../../constants/endpoints'
+import Sponsor from '../../../models/sponsor'
 import { openExternalUrl } from '../../../services/url'
 import { mockUseLoadAsyncWithData } from '../../../testing/mockUseLoadFromEndpoint'
 import renderWithTheme from '../../../testing/render'
@@ -20,6 +20,7 @@ describe('SponsorsScreen', () => {
     {
       name: 'Die Gebäudedienstleister',
       url: 'https://www.die-gebaeudedienstleister.de',
+      logo: null,
     },
   ]
 

--- a/src/services/CmsApi.ts
+++ b/src/services/CmsApi.ts
@@ -1,11 +1,13 @@
 import { Article, ARTICLES } from '../constants/data'
 import { Discipline, NetworkError, VocabularyItem } from '../constants/endpoints'
 import { isTypeLoadProtected } from '../hooks/helpers'
+import Sponsor from '../models/sponsor'
 import { getFromEndpoint } from './axios'
 
 const Endpoints = {
   jobs: 'jobs',
   job: (id: number) => `jobs/${id}`,
+  sponsors: 'sponsors',
   words: 'words',
   word: (id: number) => `words/${id}`,
 }
@@ -45,6 +47,24 @@ export const getJob = async (id: JobId): Promise<Discipline> =>
   !isTypeLoadProtected(id)
     ? transformJobsResponse(await getFromEndpoint<JobResponse>(Endpoints.job(id.disciplineId)))
     : Promise.reject(new Error(NetworkError)) // TODO: Add support back to the cms
+
+type SponsorResponse = {
+  id: number
+  name: string
+  url: string
+  logo: string | null
+}
+
+const transformSponsorResponse = ({ name, url, logo }: SponsorResponse): Sponsor => ({
+  name,
+  url: url || null,
+  logo,
+})
+
+export const getSponsors = async (): Promise<Sponsor[]> => {
+  const response = await getFromEndpoint<SponsorResponse[]>(Endpoints.sponsors)
+  return response.map(transformSponsorResponse)
+}
 
 type CMSArticle = 'keiner' | 'der' | 'die' | 'das' | 'die (Plural)'
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This pr migrates the sponsors endpoint to api v2.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add endpoint in `CmsApi.ts`
- Move the model to the models directory
- Rename `useGetAllSponsors` to `useLoadAllSponsors` to be more consistent
- Don't need sort sponsors anymore, the api does that now

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
This pr can now be tested with the test server

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1192 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
