### PR TITLE
Add the browserstack upload functionality back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,6 +422,40 @@ jobs:
                 command: tools/sentry-release "app.lunes" "${NEW_VERSION_NAME}" ~/attached_workspace/sourcemaps/ --version-code "${NEW_VERSION_CODE}"
                 name: Sentry Upload
             - notify
+    deliver_browser_stack:
+        docker:
+            - image: cimg/android:2024.08.1-node
+        environment:
+            FASTLANE_SKIP_UPDATE_CHECK: true
+        shell: /bin/bash -eo pipefail
+        steps:
+            - checkout
+            - prepare_workspace
+            - restore_ruby_cache:
+                directory: android
+            - run:
+                command: mv ~/attached_workspace/app-release.apk ~/attached_workspace/${CIRCLE_BRANCH////-}.apk
+                name: Rename apk
+            - run:
+                command: mv ~/attached_workspace/app-release.ipa ~/attached_workspace/${CIRCLE_BRANCH////-}.ipa
+                name: Rename ipa
+            - run:
+                command: bundle exec fastlane android upload_to_browserstack file_path:attached_workspace/${CIRCLE_BRANCH////-}.apk
+                name: BrowserStack Upload android
+                working_directory: android
+            - restore_ruby_cache:
+                directory: ios
+            - run:
+                command: bundle exec fastlane ios upload_to_browserstack file_path:attached_workspace/${CIRCLE_BRANCH////-}.ipa
+                name: BrowserStack Upload iOS
+                working_directory: ios
+            - run:
+                command: mv ~/attached_workspace/${CIRCLE_BRANCH////-}.apk ~/attached_workspace/app-release.apk
+                name: Undo rename apk
+            - run:
+                command: mv ~/attached_workspace/${CIRCLE_BRANCH////-}.ipa ~/attached_workspace/app-release.ipa
+                name: Undo raname ipa
+            - notify
     deliver_ios:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
@@ -556,6 +590,9 @@ jobs:
                 working_directory: ios
             - notify
 parameters:
+    run_browserstack_delivery:
+        default: false
+        type: boolean
     run_commit:
         default: true
         type: boolean
@@ -567,6 +604,34 @@ parameters:
         type: boolean
 version: 2.1
 workflows:
+    browserstack_delivery:
+        jobs:
+            - bump_version:
+                context:
+                    - mattermost
+                prepare_delivery: false
+            - build_android:
+                context:
+                    - mattermost
+                    - credentials-repo
+                    - credentials-lunes
+                requires:
+                    - bump_version
+            - build_ios:
+                context:
+                    - mattermost
+                    - fastlane-match
+                    - tuerantuer-apple
+                requires:
+                    - bump_version
+            - deliver_browser_stack:
+                context:
+                    - mattermost
+                    - browserstack
+                requires:
+                    - build_android
+                    - build_ios
+        when: << pipeline.parameters.run_browserstack_delivery >>
     commit:
         jobs:
             - check:

--- a/.circleci/src/@common.yml
+++ b/.circleci/src/@common.yml
@@ -12,3 +12,7 @@ parameters:
   run_promote:
     default: false
     type: boolean
+
+  run_browserstack_delivery:
+    default: false
+    type: boolean

--- a/.circleci/src/jobs/deliver_browser_stack.yml
+++ b/.circleci/src/jobs/deliver_browser_stack.yml
@@ -1,0 +1,33 @@
+docker:
+  - image: cimg/android:2024.08.1-node
+environment:
+  FASTLANE_SKIP_UPDATE_CHECK: true
+shell: /bin/bash -eo pipefail
+steps:
+  - checkout
+  - prepare_workspace
+  - restore_ruby_cache:
+      directory: android
+  - run:
+      name: Rename apk
+      command: mv ~/attached_workspace/app-release.apk ~/attached_workspace/${CIRCLE_BRANCH////-}.apk
+  - run:
+      name: Rename ipa
+      command: mv ~/attached_workspace/app-release.ipa ~/attached_workspace/${CIRCLE_BRANCH////-}.ipa
+  - run:
+      name: 'BrowserStack Upload android'
+      command: bundle exec fastlane android upload_to_browserstack file_path:attached_workspace/${CIRCLE_BRANCH////-}.apk
+      working_directory: android
+  - restore_ruby_cache:
+      directory: ios
+  - run:
+      name: 'BrowserStack Upload iOS'
+      command: bundle exec fastlane ios upload_to_browserstack file_path:attached_workspace/${CIRCLE_BRANCH////-}.ipa
+      working_directory: ios
+  - run:
+      name: Undo rename apk
+      command: mv ~/attached_workspace/${CIRCLE_BRANCH////-}.apk ~/attached_workspace/app-release.apk
+  - run:
+      name: Undo raname ipa
+      command: mv ~/attached_workspace/${CIRCLE_BRANCH////-}.ipa ~/attached_workspace/app-release.ipa
+  - notify

--- a/.circleci/src/workflows/browserstack_delivery.yml
+++ b/.circleci/src/workflows/browserstack_delivery.yml
@@ -1,0 +1,27 @@
+when: << pipeline.parameters.run_browserstack_delivery >>
+jobs:
+  - bump_version:
+      context:
+        - mattermost
+      prepare_delivery: false
+  - build_android:
+      context:
+        - mattermost
+        - credentials-repo
+        - credentials-lunes
+      requires:
+        - bump_version
+  - build_ios:
+      context:
+        - mattermost
+        - fastlane-match
+        - tuerantuer-apple
+      requires:
+        - bump_version
+  - deliver_browser_stack:
+      context:
+        - mattermost
+        - browserstack
+      requires:
+        - build_android
+        - build_ios

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-plugin-browserstack (0.3.4)
+      rest-client (~> 2.0, >= 2.0.2)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     gh_inspector (1.1.3)
@@ -152,6 +154,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     httpclient (2.9.0)
@@ -161,6 +164,10 @@ GEM
     jwt (2.10.2)
       base64
     logger (1.7.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0924)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     multi_json (1.17.0)
@@ -168,6 +175,7 @@ GEM
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     naturally (2.3.0)
+    netrc (0.11.0)
     nkf (0.2.0)
     optparse (0.6.0)
     os (1.1.4)
@@ -178,6 +186,11 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.4.1)
     rouge (3.28.0)
@@ -221,6 +234,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
+  fastlane-plugin-browserstack
 
 BUNDLED WITH
    2.6.9

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -90,6 +90,25 @@ platform :android do
         )
     end
 
+    desc "Upload Android App to BrowserStack"
+    lane :upload_to_browserstack do |options|
+        file_path = options[:file_path]
+
+        if [file_path].include?(nil)
+            raise "'nil' passed as parameter! Aborting..."
+        end
+
+        ensure_env_vars(
+            env_vars: ["BROWSERSTACK_USERNAME_LUNES", "BROWSERSTACK_ACCESS_KEY_LUNES"]
+        )
+
+        upload_to_browserstack_app_live(
+            browserstack_username: ENV["BROWSERSTACK_USERNAME_LUNES"],
+            browserstack_access_key: ENV["BROWSERSTACK_ACCESS_KEY_LUNES"],
+            file_path: "#{ENV['HOME']}/#{file_path}"
+        )
+    end
+
     desc "Upload Android App to Google Play"
     lane :upload_to_playstore do |options|
         ensure_env_vars(

--- a/android/fastlane/Pluginfile
+++ b/android/fastlane/Pluginfile
@@ -2,3 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
+gem 'fastlane-plugin-browserstack'

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -39,6 +39,14 @@ Validate Play Store Key
 
 Build Android App
 
+### android upload_to_browserstack
+
+```sh
+[bundle exec] fastlane android upload_to_browserstack
+```
+
+Upload Android App to BrowserStack
+
 ### android upload_to_playstore
 
 ```sh

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -50,6 +50,7 @@ Several workflows exist for different purposes:
 - **commit_main**: Executed for all commits on main. Code is checked and Android and iOS apps are build.
 - **dev_delivery**: [Manually triggerable](#triggering-a-delivery-using-the-ci) workflow which delivers builds to development/beta.
 - **promote**: [Manually triggerable](#triggering-a-delivery-using-the-ci) workflow which promotes latest beta to production.
+- **browserstack_delivery**: [Manually triggerable](#triggering-a-delivery-using-the-ci) workflow to build the ios and android app and upload it to browserstack.
 
 ## Services
 

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-plugin-browserstack (0.3.4)
+      rest-client (~> 2.0, >= 2.0.2)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     ffi (1.17.2-arm64-darwin)
@@ -215,6 +217,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     httpclient (2.9.0)
@@ -226,6 +229,10 @@ GEM
     jwt (2.10.2)
       base64
     logger (1.7.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0924)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.5)
@@ -247,6 +254,11 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.4.1)
     rouge (3.28.0)
@@ -299,6 +311,7 @@ DEPENDENCIES
   cocoapods (>= 1.16.2)
   concurrent-ruby (< 1.3.4)
   fastlane
+  fastlane-plugin-browserstack
   xcodeproj (>= 1.27.0)
 
 BUNDLED WITH

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -56,7 +56,26 @@ platform :ios do
       scheme: "Lunes",
       output_name: "app-release.ipa",
       export_method: "app-store",
-      include_bitcode: false
+      include_bitcode: false # Uploading to BrowserStack does not work when including Bitcode
+    )
+  end
+
+  desc "Upload iOS App to BrowserStack"
+  lane :upload_to_browserstack do |options|
+    file_path = options[:file_path]
+
+    if [file_path].include?(nil)
+      raise "'nil' passed as parameter! Aborting..."
+    end
+
+    ensure_env_vars(
+      env_vars: ["BROWSERSTACK_USERNAME_LUNES", "BROWSERSTACK_ACCESS_KEY_LUNES"]
+    )
+
+    upload_to_browserstack_app_live(
+      browserstack_username: ENV["BROWSERSTACK_USERNAME_LUNES"],
+      browserstack_access_key: ENV["BROWSERSTACK_ACCESS_KEY_LUNES"],
+      file_path: "#{ENV['HOME']}/#{file_path}"
     )
   end
 

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -2,3 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
+gem 'fastlane-plugin-browserstack'

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -23,6 +23,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Create a release build
 
+### ios upload_to_browserstack
+
+```sh
+[bundle exec] fastlane ios upload_to_browserstack
+```
+
+Upload iOS App to BrowserStack
+
 ### ios upload_to_appstoreconnect
 
 ```sh


### PR DESCRIPTION
### Short Description
This mostly reverts pr #1130, the only difference is that the upload to browserstack does not get triggered automatically anymore.

The reason for reverting the commit is that we want to make it simpler for the ui/ux team to test pull requests.
This is a first step towards the goal, because it allows testing a pull request in the web without having a dev environment configured.

I think ideally we want an easier way to trigger the pipeline (for example by adding a label to a pull request) and a way to get a pr comment that contains the correct browserstack urls. But this can also be done manually for now.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Revert #1130, but do not run the workflow in `commit` or `commit_main`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
It seems to work: https://circleci.com/gh/digitalfabrik/lunes-app/12792

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: Part of #1160 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
