### PR TITLE
Refactor user vocabulary units

### DIFF
--- a/src/routes/user-vocabulary-unit-selection/splitVocabularyToUnits.ts
+++ b/src/routes/user-vocabulary-unit-selection/splitVocabularyToUnits.ts
@@ -3,43 +3,25 @@ import { getLabels } from '../../services/helpers'
 import { UnitWithVocabulary } from './UserVocabularyUnitSelectionScreen'
 
 const DISCIPLINE_SIZE = 10
-let unitsWithVocabulary: UnitWithVocabulary[] = []
 
-const createUnits = (vocabularySize: number) => {
-  for (let i = 0; i < vocabularySize / DISCIPLINE_SIZE; i += 1) {
-    unitsWithVocabulary.push({
-      unit: {
-        id: { index: i, type: 'user-vocabulary-unit' },
-        title: `${getLabels().userVocabulary.practice.part} ${i + 1}`,
-        description: '',
-        numberWords: 1,
-        iconUrl: null,
-      },
-      vocabulary: [],
-    })
+const groupVocabulary = (vocabulary: VocabularyItem[]): VocabularyItem[][] => {
+  const result: VocabularyItem[][] = []
+  for (let i = 0; i < vocabulary.length / DISCIPLINE_SIZE; i += 1) {
+    result.push(vocabulary.slice(i * DISCIPLINE_SIZE, (i + 1) * DISCIPLINE_SIZE))
   }
-}
-
-const moveVocabularyToCorrectDiscipline = (vocabulary: VocabularyItem[]) => {
-  vocabulary.forEach((item, index) => {
-    unitsWithVocabulary[Math.floor(index / DISCIPLINE_SIZE)].vocabulary.push(item)
-  })
-}
-
-const adjustChildrenSizeOfDisciplines = () => {
-  unitsWithVocabulary = unitsWithVocabulary.map(item => ({
-    ...item,
-    unit: {
-      ...item.unit,
-      numberOfChildren: item.vocabulary.length,
-    },
-  }))
+  return result
 }
 
 export const splitVocabularyIntoDisciplines = (vocabulary: VocabularyItem[]): UnitWithVocabulary[] => {
-  unitsWithVocabulary = []
-  createUnits(vocabulary.length)
-  moveVocabularyToCorrectDiscipline(vocabulary)
-  adjustChildrenSizeOfDisciplines()
-  return unitsWithVocabulary
+  const groups = groupVocabulary(vocabulary)
+  return groups.map((vocabulary, index) => ({
+    unit: {
+      id: { index, type: 'user-vocabulary-unit' },
+      title: `${getLabels().userVocabulary.practice.part} ${index + 1}`,
+      description: '',
+      numberWords: vocabulary.length,
+      iconUrl: null,
+    },
+    vocabulary,
+  }))
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Small refactor to the 'splitVocabularyToUnits.ts' file.
I wanted to avoid ugly rebases, so I hope it is okay that this merges into `use-api-v2` 😁 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Don't use global state
- Rely less on mutation

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

The app behavior should not change

### Testing

<!-- List all things that should be tested while reviewing this PR. -->


### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1207 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
