### PR TITLE
Fix language displayed in the app store

### DIFF
--- a/ios/Lunes/Info.plist
+++ b/ios/Lunes/Info.plist
@@ -9,7 +9,7 @@
         <string>tel</string>
     </array>
     <key>CFBundleDevelopmentRegion</key>
-    <string>en</string>
+    <string>de</string>
     <key>CFBundleDisplayName</key>
     <string>Lunes</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
I am not 100% certain that this is the correct solution unfortunately.
If this fixes the problem, we will see it after making the next beta release.

Apple docs: https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundledevelopmentregion

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace 'en' with 'de' in `info.plist`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
I think the only way to test this is by making a new beta release

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1230 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
