### PR TITLE
Ci: Update xcode to 26.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
             FL_OUTPUT_DIR: output
             TOTAL_CPUS: 6
         macos:
-            xcode: 16.2.0
+            xcode: 26.2.0
         resource_class: m4pro.medium
         shell: /bin/bash --login -o pipefail
         steps:
@@ -472,7 +472,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.2.0
+            xcode: 26.2.0
         parameters:
             production_delivery:
                 default: false
@@ -591,7 +591,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.2.0
+            xcode: 26.2.0
         resource_class: m4pro.medium
         shell: /bin/bash --login -o pipefail
         steps:

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,5 +1,5 @@
 macos:
-  xcode: 16.2.0
+  xcode: 26.2.0
 resource_class: m4pro.medium
 environment:
   FL_OUTPUT_DIR: output

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -4,7 +4,7 @@ parameters:
     type: boolean
     default: false
 macos:
-  xcode: 16.2.0
+  xcode: 26.2.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash --login -o pipefail

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -1,6 +1,6 @@
 # Promotes the app from Testflight to the Apple App Store.
 macos:
-  xcode: 16.2.0
+  xcode: 26.2.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 resource_class: m4pro.medium


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The old version 16.2.0 was deprecated by circleci: https://circleci.com/changelog/deprecation-of-xcode-16-2/

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update Xcode to 26.2.0

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Ci checks should still be green

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
