### PR TITLE
Fix warning about line height without units

### DIFF
--- a/src/components/ProgressHint.tsx
+++ b/src/components/ProgressHint.tsx
@@ -21,7 +21,7 @@ const Container = styled.View`
 const StyledText = styled.Text`
   font-size: ${props => props.theme.fonts.defaultFontSize};
   font-weight: ${props => props.theme.fonts.defaultFontWeight};
-  line-height: 24;
+  line-height: 24px;
 `
 
 const StyledFakeButton = styled.Text`


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Looks like we are accidentally creating some css without units, which the react devtools warn about:
<img width="617" height="380" alt="image" src="https://github.com/user-attachments/assets/339d3c24-300f-4f9a-9b80-7a1b709a33ef" />


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Explicitly specify the unit

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: nothing

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
