### PR TITLE
1289 use xcode 26 in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
             FL_OUTPUT_DIR: output
             TOTAL_CPUS: 6
         macos:
-            xcode: 16.4.0
+            xcode: 26.3.0
         resource_class: m4pro.medium
         shell: /bin/bash --login -o pipefail
         steps:
@@ -472,7 +472,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.4.0
+            xcode: 26.3.0
         parameters:
             production_delivery:
                 default: false
@@ -591,7 +591,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.4.0
+            xcode: 26.3.0
         resource_class: m4pro.medium
         shell: /bin/bash --login -o pipefail
         steps:

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,5 +1,5 @@
 macos:
-  xcode: 16.4.0
+  xcode: 26.3.0
 resource_class: m4pro.medium
 environment:
   FL_OUTPUT_DIR: output

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -4,7 +4,7 @@ parameters:
     type: boolean
     default: false
 macos:
-  xcode: 16.4.0
+  xcode: 26.3.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash --login -o pipefail

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -1,6 +1,6 @@
 # Promotes the app from Testflight to the Apple App Store.
 macos:
-  xcode: 16.4.0
+  xcode: 26.3.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 resource_class: m4pro.medium


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
We need to use the new xcode version when building the app, otherwise apple won't let us publish new updates.

~~Currently a draft, until the ci testing finishes~~ CI looks good

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use the new images

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Will be done in ci

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1289

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
