### PR TITLE
Fix cms url overwrite not being persistent

### DIFF
--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -243,7 +243,7 @@ export const migrate3To4 = async (): Promise<void> => {
 // Removes the cms url overwrite value in case it has changed between versions
 export const migrateApiEndpointUrl = async (): Promise<void> => {
   const overwrite = await AsyncStorage.getItem(storageKeys.cmsUrlOverwrite)
-  if (overwrite !== null && !(CMS_URLS as readonly string[]).includes(overwrite)) {
+  if (overwrite !== null && !(CMS_URLS as readonly string[]).includes(JSON.parse(overwrite))) {
     await AsyncStorage.removeItem(storageKeys.cmsUrlOverwrite)
   }
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
I am quite surprised that I never noticed before that the cms url does not persist across app restarts.
The problem is at the migration code which resets the overwrite if it does not know the value, which has a buggy comparison.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Correctly deserialize the existing value before comparing it (Before it was comparing e.g. `https://server-url` with `"https://server-url"`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none 

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
The setting should now not reset after app restarts any more

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1293

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
