### PR TITLE
Correctly pluralize in the image training screen

### DIFF
--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -93,9 +93,11 @@ export type ArticleTypeExtended = {
   readonly label: string
 } & ArticleType
 
+export const isArticlePlural = (article: ArticleType): boolean => article.id === 4
+
 export const getArticleWithLabel = (): ArticleTypeExtended[] =>
   ARTICLES.filter(article => article.id !== 0).map(article => {
-    if (article.id === 4) {
+    if (isArticlePlural(article)) {
       return { ...article, label: `${article.value} (Plural)` }
     }
     return { ...article, label: article.value }

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -78,7 +78,8 @@
         "title": "Bilderrätsel",
         "description": "Die richtige Vokabel finden",
         "selectImage": "Wähle das richtige Bild aus!",
-        "whatIs": "Was ist"
+        "whatIs": "Was ist",
+        "whatAre": "Was sind"
       },
       "voice": {
         "title": "Sprechstudio",

--- a/src/routes/training/ImageTrainingScreen.tsx
+++ b/src/routes/training/ImageTrainingScreen.tsx
@@ -10,7 +10,7 @@ import Button from '../../components/Button'
 import RouteWrapper from '../../components/RouteWrapper'
 import ServerResponseHandler from '../../components/ServerResponseHandler'
 import { ContentText, ContentTextBold } from '../../components/text/Content'
-import { BUTTONS_THEME, MAX_TRAINING_REPETITIONS } from '../../constants/data'
+import { BUTTONS_THEME, isArticlePlural, MAX_TRAINING_REPETITIONS } from '../../constants/data'
 import useLoadWordsByJob from '../../hooks/useLoadWordsByJob'
 import { StandardJob } from '../../models/Job'
 import VocabularyItem, { VocabularyItemId } from '../../models/VocabularyItem'
@@ -157,6 +157,10 @@ const ImageTraining = ({ vocabularyItems, navigation, job }: ImageTrainingProps)
     />
   )
 
+  const questionLabel = isArticlePlural(word.article)
+    ? getLabels().exercises.training.image.whatAre
+    : getLabels().exercises.training.image.whatIs
+
   return (
     <>
       <TrainingExerciseHeader
@@ -168,7 +172,7 @@ const ImageTraining = ({ vocabularyItems, navigation, job }: ImageTrainingProps)
       <TrainingExerciseContainer title={getLabels().exercises.training.image.selectImage} footer={nextWordButton}>
         <QuestionContainer>
           <ContentText>
-            {getLabels().exercises.training.image.whatIs} {word.article.value}{' '}
+            {questionLabel} {word.article.value}{' '}
           </ContentText>
           <ContentTextBold>{word.word}</ContentTextBold>
           <ContentText>?</ContentText>

--- a/src/routes/training/__tests__/ImageTrainingScreen.spec.tsx
+++ b/src/routes/training/__tests__/ImageTrainingScreen.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, waitFor } from '@testing-library/react-native'
 import { mocked } from 'jest-mock'
 import React from 'react'
 
-import { MAX_TRAINING_REPETITIONS } from '../../../constants/data'
+import { ARTICLES, MAX_TRAINING_REPETITIONS } from '../../../constants/data'
 import { RoutesParams } from '../../../navigation/NavigationTypes'
 import { getWordsByJob } from '../../../services/CmsApi'
 import { getLabels } from '../../../services/helpers'
@@ -53,7 +53,7 @@ describe('ImageTrainingScreen', () => {
   }
 
   it('should render initially', async () => {
-    const { getByText, getAllByTestId, getByTestId } = await renderScreenAndWaitForLoad()
+    const { getByText, queryByText, getAllByTestId, getByTestId } = await renderScreenAndWaitForLoad()
 
     expect(getByText(getLabels().exercises.training.image.selectImage)).toBeVisible()
     expect(getAllByTestId('imageOption')).toHaveLength(4)
@@ -61,6 +61,17 @@ describe('ImageTrainingScreen', () => {
 
     const skipButton = getByTestId('button-skip')
     expect(skipButton).toBeVisible()
+
+    expect(queryByText(getLabels().exercises.training.image.whatAre, { exact: false })).toBeNull()
+    expect(getByText(getLabels().exercises.training.image.whatIs, { exact: false })).toBeVisible()
+  })
+
+  it('should correctly use plural form', async () => {
+    mocked(getWordsByJob).mockResolvedValue(vocabularyItems.map(item => ({ ...item, article: ARTICLES[4] })))
+
+    const { getByText, queryByText } = await renderScreenAndWaitForLoad()
+    expect(getByText(getLabels().exercises.training.image.whatAre, { exact: false })).toBeVisible()
+    expect(queryByText(getLabels().exercises.training.image.whatIs, { exact: false })).toBeNull()
   })
 
   it('should keep Skip button after selecting incorrect image', async () => {


### PR DESCRIPTION


### Short Description

<!-- Describe this PR in one or two sentences. -->
Small bugfix for words which have the "die (Plural)" article assigned.
As an example, we showed "Was ist die **Lötfittings**?" before. Now the correct grammar is used for plural words:

<img width="470" height="925" alt="image" src="https://github.com/user-attachments/assets/f50b2e5a-55ba-43d1-8d56-e4bf675bc684" />


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Check if the article is plural, and show the correct question

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
A bit annoying to test, since there are not many words with plural articles. You could create a custom job in the test cms or select "Anlagenmechaniker:in für Sanitär-, Heizungs- und Klimatechnik" and reroll the image training until you get "Lötfittings".
Other plural words I could find in the test system: "Instrumente" and "Lippen"

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Didn't create an issue for it

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
