### PR TITLE
Fix the audio player for the word choice exercise

### DIFF
--- a/src/components/VocabularyItemImageSection.tsx
+++ b/src/components/VocabularyItemImageSection.tsx
@@ -27,6 +27,7 @@ const Container = styled.View`
 type VocabularyItemSectionProps = {
   vocabularyItem: VocabularyItem
   audioDisabled?: boolean
+  showAudioPlayer?: boolean
   minimized?: boolean
   submittedAlternative?: string | null
 }
@@ -34,19 +35,22 @@ type VocabularyItemSectionProps = {
 const VocabularyItemImageSection = ({
   vocabularyItem,
   audioDisabled = false,
+  showAudioPlayer = true,
   minimized = false,
   submittedAlternative,
 }: VocabularyItemSectionProps): ReactElement => (
   <Container>
     <ImageCarousel images={vocabularyItem.images} minimized={minimized} />
-    <AudioContainer>
-      <AudioPlayer
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- False positive, left hand side is possible null or undefined
-        audio={submittedAlternative ?? vocabularyItem.audio ?? stringifyVocabularyItem(vocabularyItem)}
-        isTtsText={!!submittedAlternative || !vocabularyItem.audio}
-        disabled={audioDisabled}
-      />
-    </AudioContainer>
+    {showAudioPlayer && (
+      <AudioContainer>
+        <AudioPlayer
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- False positive, left hand side is possible null or undefined
+          audio={submittedAlternative ?? vocabularyItem.audio ?? stringifyVocabularyItem(vocabularyItem)}
+          isTtsText={!!submittedAlternative || !vocabularyItem.audio}
+          disabled={audioDisabled}
+        />
+      </AudioContainer>
+    )}
     <FavoriteContainer>
       <FavoriteButton vocabularyItem={vocabularyItem} />
     </FavoriteContainer>

--- a/src/routes/choice-exercises/components/WordChoiceExercise.tsx
+++ b/src/routes/choice-exercises/components/WordChoiceExercise.tsx
@@ -5,6 +5,7 @@ import { ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ArrowRightIcon } from '../../../../assets/images'
+import AudioPlayer from '../../../components/AudioPlayer'
 import Button from '../../../components/Button'
 import CheatMode from '../../../components/CheatMode'
 import ExerciseHeader from '../../../components/ExerciseHeader'
@@ -80,6 +81,10 @@ const SolutionRow = styled.View`
   align-items: center;
   justify-content: center;
   padding: ${props => props.theme.spacings.xs} 0;
+`
+
+const AudioPlayerContainer = styled.View`
+  padding-right: ${props => props.theme.spacings.xs};
 `
 
 type WordChoiceExerciseProps = {
@@ -210,7 +215,7 @@ const WordChoiceExercise = ({
       />
 
       <ScrollView>
-        <VocabularyItemImageSection vocabularyItem={vocabularyItem} audioDisabled={selectedAnswer === null} />
+        <VocabularyItemImageSection vocabularyItem={vocabularyItem} showAudioPlayer={false} />
         <SingleChoice
           answers={state.answers}
           isAnswerEqual={isAnswerEqual}
@@ -237,6 +242,10 @@ const WordChoiceExercise = ({
         isCorrect={!needsToBeRepeated}
         content={
           <SolutionRow>
+            <AudioPlayerContainer>
+              <AudioPlayer disabled={vocabularyItem.audio === null} audio={vocabularyItem.audio ?? ''} />
+            </AudioPlayerContainer>
+
             {needsToBeRepeated && <ContentText>{getLabels().exercises.solution}</ContentText>}
             <ContentText>
               {vocabularyItem.article.value} {vocabularyItem.word}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
In an oversight, #1308 made the audio player useless. This pr fixes that.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move the audio player into the bottom sheet, so that it is clickable again
- Unrelated, but I found a slight styling issue where long words could overflow, which I also fixed

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Audio player should work again in the word choice exercises

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1311 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
