### PR TITLE
Fix result being incorrectly shown as correct at third try

### DIFF
--- a/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
+++ b/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
@@ -182,6 +182,29 @@ describe('WordChoiceExerciseScreen', () => {
     })
   })
 
+  it('should show the answer as incorrect after answering wrong NUMBER_OF_MAX_RETRIES times', () => {
+    const { getByText } = renderScreen()
+
+    // Answer Spachtel wrong once - moves to end of queue (index 3)
+    fireEvent(getByText('Auto'), 'pressOut')
+    fireEvent.press(getByText(getLabels().exercises.next))
+
+    // Complete the remaining words correctly so Spachtel is reached again
+    selectAnswerAndPressNext(getByText, 'Auto')
+    selectAnswerAndPressNext(getByText, 'Hose')
+    selectAnswerAndPressNext(getByText, 'Helm')
+
+    // Answer Spachtel wrong a second time - still at end of queue, numberOfTries=2
+    fireEvent(getByText('Auto'), 'pressOut')
+    fireEvent.press(getByText(getLabels().exercises.next))
+
+    // Answer Spachtel wrong a third time, reaching NUMBER_OF_MAX_RETRIES
+    fireEvent(getByText('Auto'), 'pressOut')
+
+    // The result indicator must still show "incorrect", not "correct"
+    expect(getByText(getLabels().exercises.training.sentence.incorrect)).toBeVisible()
+  })
+
   describe('repetition exercise', () => {
     const repetitionRoute: RouteProp<RoutesParams, 'WordChoiceExercise'> = {
       key: '',

--- a/src/routes/choice-exercises/components/WordChoiceExercise.tsx
+++ b/src/routes/choice-exercises/components/WordChoiceExercise.tsx
@@ -239,7 +239,7 @@ const WordChoiceExercise = ({
 
       <WordResultIndicator
         isVisible={selectedAnswer !== null}
-        isCorrect={!needsToBeRepeated}
+        isCorrect={result === SIMPLE_RESULTS.correct}
         content={
           <SolutionRow>
             <AudioPlayerContainer>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fixes the bug discovered by @JoeyStk that the result indicator was incorrectly showing a success message when a word was answered wrong after the third try.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Fix the condition whether an answer has been correct

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
