### PR TITLE
Fix the feedback menu being behind system navigation on android

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ const App = (): ReactElement => {
             <VolumeServiceProvider>
               <TtsServiceProvider>
                 <NavigationContainer>
-                  <HeaderButtonsProvider stackType='native'>
+                  <HeaderButtonsProvider stackType='native' spaceAboveMenu={initialWindowMetrics?.insets.top ?? 0}>
                     <Navigator />
                   </HeaderButtonsProvider>
                 </NavigationContainer>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The fix is to simply add some offset at the header buttons provider. Newer versions of this library already implement this fix, but are unfortunately not compatible with our version of react native

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add the offset

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that the feedback popups don't show up behind the navigation bar on android anymore.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1314

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
