### PR TITLE
Fix github release creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,7 +523,7 @@ jobs:
             - run:
                 command: |
                     echo "Creating release ${NEW_VERSION_NAME}..."
-                    RELEASE='$(yarn app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME})'
+                    RELEASE=$(yarn app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME})
                     echo "${RELEASE}"
                     echo "export RELEASE_ID=$(echo "${RELEASE}" | jq .id)" >> ${BASH_ENV}
                 name: Create github release

--- a/.circleci/src/jobs/notify_github.yml
+++ b/.circleci/src/jobs/notify_github.yml
@@ -14,7 +14,7 @@ steps:
       name: Create github release
       command: |
         echo "Creating release ${NEW_VERSION_NAME}..."
-        RELEASE='$(yarn app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME})'
+        RELEASE=$(yarn app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME})
         echo "${RELEASE}"
         echo "export RELEASE_ID=$(echo "${RELEASE}" | jq .id)" >> ${BASH_ENV}
       working_directory: tools


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
The command to create a new github release was not executed, because it was wrapped in single quotes (''), which prevent all string interpolation in bash. The fix to just remove them also matches what the integreat app does: https://github.com/digitalfabrik/integreat-app/blob/ba803418a36c77892336abbda5d8bc337c3db05f/.circleci/src/jobs/notify_release.yml#L21

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the single quotes

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
lets test it in the next beta release 😁 

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
