### PR TITLE
Set CMS URL overwrite to null if the base url is not known

### DIFF
--- a/src/routes/settings/components/DebugModal.tsx
+++ b/src/routes/settings/components/DebugModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { widthPercentageToDP as wp } from 'react-native-responsive-screen'
 import styled from 'styled-components/native'
 
@@ -57,7 +57,7 @@ const DebugModal = (props: DebugModalProps): ReactElement => {
   }
 
   const switchCMS = async (): Promise<void> => {
-    let updatedCMS: CMS
+    let updatedCMS: CMS | null = null
     switch (baseURL) {
       case productionCMS: {
         updatedCMS = localhostCMS

--- a/src/routes/settings/components/__tests__/DebugModal.spec.tsx
+++ b/src/routes/settings/components/__tests__/DebugModal.spec.tsx
@@ -1,9 +1,10 @@
 import { act, fireEvent, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
+import { StorageCache } from '../../../../services/Storage'
 import { localhostCMS, productionCMS, testCMS } from '../../../../services/axios'
 import { getLabels } from '../../../../services/helpers'
-import render from '../../../../testing/render'
+import render, { renderWithStorageCache } from '../../../../testing/render'
 import DebugModal from '../DebugModal'
 
 describe('DebugModal', () => {
@@ -38,6 +39,21 @@ describe('DebugModal', () => {
       fireEvent.press(switchCMSButton)
     })
     await waitFor(() => expect(getByText(testCMS)).toBeDefined())
+  })
+
+  it('should switch cms url also if the current setting is unknown', async () => {
+    const storageCache = StorageCache.createDummy()
+    // @ts-expect-error the url might have an invalid value due to version changes
+    await storageCache.setItem('cmsUrlOverwrite', 'InvalidUrl')
+    const { getByText } = renderWithStorageCache(
+      storageCache,
+      <DebugModal isCodeRequired={false} visible onClose={jest.fn()} />,
+    )
+    await waitFor(() => expect(getByText('InvalidUrl')).toBeVisible())
+    const switchCMSButton = getByText(getLabels().settings.debugModal.changeCMS)
+    expect(switchCMSButton).toBeVisible()
+    fireEvent.press(switchCMSButton)
+    await waitFor(() => expect(getByText(testCMS)).toBeVisible())
   })
 
   it('should show and toggle devmode status', async () => {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This pr makes sure that it is possible to change the cms url overwrite if the current value is invalid, so that the app does not have to be reinstalled after upgrading.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- If no known url was matched, set the overwrite to null

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Upgrading with an old CMS URL overwrite will still break the app initially, but at least it is now possible to fix the overwrite in the debug menu 

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Added a new test for this case

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1328

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
