### PR TITLE
Fix URL for testing against local CMS on iOS

### DIFF
--- a/src/routes/settings/components/DebugModal.tsx
+++ b/src/routes/settings/components/DebugModal.tsx
@@ -11,7 +11,15 @@ import { loadAllWords } from '../../../hooks/useLoadAllWords'
 import useRepetitionService from '../../../hooks/useRepetitionService'
 import useStorage, { useStorageCache } from '../../../hooks/useStorage'
 import { RepetitionService, sections } from '../../../services/RepetitionService'
-import { CMS, getBaseURL, localhostCMS, productionCMS, testCMS } from '../../../services/axios'
+import {
+  CMS,
+  getBaseURL,
+  localhostCMS,
+  localhostCMSAndroid,
+  localhostCMSIOS,
+  productionCMS,
+  testCMS,
+} from '../../../services/axios'
 import { getLabels, getRandomNumberBetween } from '../../../services/helpers'
 import { reportError } from '../../../services/sentry'
 
@@ -63,7 +71,8 @@ const DebugModal = (props: DebugModalProps): ReactElement => {
         updatedCMS = localhostCMS
         break
       }
-      case localhostCMS: {
+      case localhostCMSAndroid:
+      case localhostCMSIOS: {
         updatedCMS = testCMS
         break
       }

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -5,8 +5,9 @@ import DeviceInfo from 'react-native-device-info'
 
 import { getStorageItem } from './Storage'
 
-// Android emulator treats this special ip as the localhost of the host, iOS simulator uses localhost
-export const localhostCMS = `http://${Platform.OS === 'android' ? '10.0.2.2' : 'localhost'}:8080/api/v2`
+export const localhostCMSAndroid = 'http://10.0.2.2/api/v2'
+export const localhostCMSIOS = 'http://localhost/api/v2'
+export const localhostCMS = Platform.OS === 'android' ? localhostCMSAndroid : localhostCMSIOS
 export const testCMS = 'https://lunes-test.tuerantuer.org/api/v2'
 export const productionCMS = 'https://lunes.tuerantuer.org/api/v2'
 export const CMS_URLS = [localhostCMS, testCMS, productionCMS] as const


### PR DESCRIPTION
### Short Description

This just enables testing against the local CMS on an iOS emulator (which uses localhost) while keeping the special IP for Android :)