### PR TITLE
1342: Fix image loading on ios for the image training exercise

### DIFF
--- a/src/routes/training/__tests__/ImageTrainingScreen.spec.tsx
+++ b/src/routes/training/__tests__/ImageTrainingScreen.spec.tsx
@@ -49,6 +49,7 @@ describe('ImageTrainingScreen', () => {
   const renderScreenAndWaitForLoad = async () => {
     const result = renderWithTheme(<ImageTrainingScreen navigation={navigation} route={route} />)
     await expect(result.findByText(getLabels().exercises.training.image.selectImage)).resolves.toBeVisible()
+    fireEvent(result.getByTestId('image-grid'), 'layout', { nativeEvent: { layout: { width: 300 } } })
     return result
   }
 

--- a/src/routes/training/components/ImageGrid.tsx
+++ b/src/routes/training/components/ImageGrid.tsx
@@ -69,12 +69,13 @@ const ImageGrid = ({ items, onPress }: ImageGridProps): ReactElement => {
   }
 
   return (
-    <Grid onLayout={onGridLayout}>
-      {items.map(item => (
-        <PressableOpacity key={JSON.stringify(item.key)} onPress={() => onPress(item.key)} testID='imageOption'>
-          <StyledImage src={item.src} width={imageWidth} padding={paddingPx} state={item.state} />
-        </PressableOpacity>
-      ))}
+    <Grid onLayout={onGridLayout} testID='image-grid'>
+      {availableWidth > 0 &&
+        items.map(item => (
+          <PressableOpacity key={JSON.stringify(item.key)} onPress={() => onPress(item.key)} testID='imageOption'>
+            <StyledImage src={item.src} width={imageWidth} padding={paddingPx} state={item.state} />
+          </PressableOpacity>
+        ))}
     </Grid>
   )
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Changes the ImageGrid to not display the images if the available width has not been calculated yet and is zero.
I am not sure what the exact problem was, but my best guess is that some upgrade of react native changed the behavior of images on ios when the size of the image changes, to not reload the image any more.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Only display the images in the image grid when we have a valid value for the available width

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that it still works on android and that it fixes the bug on ios

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1342

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
