### PR TITLE
1259: Track module duration of exercises

### DIFF
--- a/src/hooks/__tests__/useTrackMountDuration.spec.ts
+++ b/src/hooks/__tests__/useTrackMountDuration.spec.ts
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react-native'
+
+import useTrackMountDuration from '../useTrackMountDuration'
+
+describe('useTrackMountDuration', () => {
+  it('should call onUnmount with duration in seconds', () => {
+    const onUnmount = jest.fn()
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(6000)
+
+    const { unmount } = renderHook(() => useTrackMountDuration(onUnmount))
+
+    expect(onUnmount).not.toHaveBeenCalled()
+    unmount()
+    expect(onUnmount).toHaveBeenCalledWith(5)
+    expect(onUnmount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useTrackMountDuration.ts
+++ b/src/hooks/useTrackMountDuration.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react'
+
+const MILLISECONDS_PER_SECOND = 1000
+
+const useTrackMountDuration = (onUnmount: (durationSeconds: number) => void): void => {
+  const [mountDate] = useState(Date.now)
+  useEffect(
+    () => () => onUnmount(Math.round((Date.now() - mountDate) / MILLISECONDS_PER_SECOND)),
+    [mountDate, onUnmount],
+  )
+}
+
+export default useTrackMountDuration

--- a/src/routes/VocabularyListScreen.tsx
+++ b/src/routes/VocabularyListScreen.tsx
@@ -1,13 +1,15 @@
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useEffect, ReactElement } from 'react'
+import React, { ReactElement, useEffect } from 'react'
 
 import ExerciseHeader from '../components/ExerciseHeader'
 import RouteWrapper from '../components/RouteWrapper'
 import VocabularyList from '../components/VocabularyList'
 import { ExerciseKeys } from '../constants/data'
 import { useStorageCache } from '../hooks/useStorage'
+import useTrackMountDuration from '../hooks/useTrackMountDuration'
 import { RoutesParams } from '../navigation/NavigationTypes'
+import { trackEvent } from '../services/AnalyticsService'
 import { reportError } from '../services/sentry'
 import { setExerciseProgress } from '../services/storageUtils'
 
@@ -21,6 +23,16 @@ const VocabularyListScreen = ({ route, navigation }: VocabularyListScreenProps):
   const unitId = contentType === 'standard' ? route.params.unitId : null
   const storageCache = useStorageCache()
 
+  useTrackMountDuration(durationSeconds => {
+    if (unitId !== null) {
+      trackEvent(storageCache, {
+        type: 'module_duration',
+        duration_seconds: durationSeconds,
+        unit_id: unitId.id,
+        exercise_type: ExerciseKeys.vocabularyList,
+      })
+    }
+  })
   useEffect(() => {
     if (unitId !== null) {
       setExerciseProgress(storageCache, unitId, ExerciseKeys.vocabularyList, 1).catch(reportError)

--- a/src/routes/__tests__/VocabularyListScreen.spec.tsx
+++ b/src/routes/__tests__/VocabularyListScreen.spec.tsx
@@ -1,7 +1,9 @@
 import { RouteProp } from '@react-navigation/native'
 import React from 'react'
 
+import { ExerciseKeys } from '../../constants/data'
 import { RoutesParams } from '../../navigation/NavigationTypes'
+import { trackEvent } from '../../services/AnalyticsService'
 import { StorageCache } from '../../services/Storage'
 import { getLabels } from '../../services/helpers'
 import { setExerciseProgress } from '../../services/storageUtils'
@@ -26,6 +28,10 @@ jest.mock('../../components/AudioPlayer', () => {
 })
 
 jest.mock('../../components/FeedbackBadge', () => () => null)
+
+jest.mock('../../services/AnalyticsService', () => ({
+  trackEvent: jest.fn(),
+}))
 
 describe('VocabularyListScreen', () => {
   const vocabularyItems = new VocabularyItemBuilder(2).build()
@@ -64,5 +70,21 @@ describe('VocabularyListScreen', () => {
     expect(getByText('Auto')).toBeTruthy()
     expect(getAllByText('AudioPlayer')).toHaveLength(2)
     expect(getAllByTestId('image')).toHaveLength(2)
+  })
+
+  it('should track module duration on unmount', () => {
+    const { unmount } = renderWithStorageCache(
+      storageCache,
+      <VocabularyListScreen route={route} navigation={navigation} />,
+    )
+
+    expect(trackEvent).not.toHaveBeenCalled()
+    unmount()
+    expect(trackEvent).toHaveBeenCalledWith(storageCache, {
+      type: 'module_duration',
+      duration_seconds: expect.any(Number),
+      unit_id: 1,
+      exercise_type: ExerciseKeys.vocabularyList,
+    })
   })
 })

--- a/src/routes/choice-exercises/WordChoiceExerciseScreen.tsx
+++ b/src/routes/choice-exercises/WordChoiceExerciseScreen.tsx
@@ -3,7 +3,11 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
 import RouteWrapper from '../../components/RouteWrapper'
+import { ExerciseKeys } from '../../constants/data'
+import { useStorageCache } from '../../hooks/useStorage'
+import useTrackMountDuration from '../../hooks/useTrackMountDuration'
 import { RoutesParams } from '../../navigation/NavigationTypes'
+import { trackEvent } from '../../services/AnalyticsService'
 import WordChoiceExercise from './components/WordChoiceExercise'
 
 type WordChoiceExerciseScreenProps = {
@@ -15,6 +19,18 @@ const WordChoiceExerciseScreen = ({ navigation, route }: WordChoiceExerciseScree
   const { vocabularyItems, contentType } = route.params
   const unitId = contentType === 'standard' ? route.params.unitId : null
   const isRepetitionExercise = contentType === 'repetition'
+
+  const storageCache = useStorageCache()
+  useTrackMountDuration(durationSeconds => {
+    if (unitId !== null) {
+      trackEvent(storageCache, {
+        type: 'module_duration',
+        duration_seconds: durationSeconds,
+        unit_id: unitId.id,
+        exercise_type: ExerciseKeys.wordChoiceExercise,
+      })
+    }
+  })
 
   return (
     <RouteWrapper shouldSetBottomInset>

--- a/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
+++ b/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
@@ -4,7 +4,9 @@ import React from 'react'
 import { Image, View } from 'react-native'
 
 import { BottomSheetProps } from '../../../components/BottomSheet'
+import { ExerciseKeys } from '../../../constants/data'
 import { RoutesParams } from '../../../navigation/NavigationTypes'
+import { trackEvent } from '../../../services/AnalyticsService'
 import { RepetitionService } from '../../../services/RepetitionService'
 import { StorageCache } from '../../../services/Storage'
 import { getLabels } from '../../../services/helpers'
@@ -52,6 +54,10 @@ jest.mock('react-native/Libraries/LogBox/Data/LogBoxData')
 
 jest.mock('../../../services/storageUtils', () => ({
   saveExerciseProgress: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../../services/AnalyticsService', () => ({
+  trackEvent: jest.fn(),
 }))
 
 describe('WordChoiceExerciseScreen', () => {
@@ -234,6 +240,19 @@ describe('WordChoiceExerciseScreen', () => {
       fireEvent.press(getByText('Spachtel'))
 
       await waitFor(() => expect(repetitionService.getWordNodeCards()[0].section).toBe(1))
+    })
+  })
+
+  it('should track module duration on unmount', () => {
+    const { unmount } = renderScreen()
+
+    expect(trackEvent).not.toHaveBeenCalled()
+    unmount()
+    expect(trackEvent).toHaveBeenCalledWith(storageCache, {
+      type: 'module_duration',
+      duration_seconds: expect.any(Number),
+      unit_id: 1,
+      exercise_type: ExerciseKeys.wordChoiceExercise,
     })
   })
 })

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -14,11 +14,18 @@ export type AnalyticsEvent = {
   payload: AnalyticsPayload
 }
 
-export type AnalyticsPayload = {
-  type: 'job_selected'
-  job_id: number
-  action: 'add' | 'remove'
-}
+export type AnalyticsPayload =
+  | {
+      type: 'job_selected'
+      job_id: number
+      action: 'add' | 'remove'
+    }
+  | {
+      type: 'module_duration'
+      exercise_type: number
+      unit_id: number
+      duration_seconds: number
+    }
 
 export const isConsentGiven = (storageCache: StorageCache): boolean => {
   const consent = storageCache.getItem('analyticsConsent')


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Tracks the duration users spend in exercises. This does not include training exercises for now, because we still need to decide how to handle those.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add `useTrackMountDuration` hook
- Update the two exercises to send tracking events
- Add tests

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that the events are sent to the server and registered there.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1259

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
