### PR TITLE
1352: Unit name as title of vocabulary list screen

### DIFF
--- a/src/routes/VocabularyListScreen.tsx
+++ b/src/routes/VocabularyListScreen.tsx
@@ -8,7 +8,6 @@ import VocabularyList from '../components/VocabularyList'
 import { ExerciseKeys } from '../constants/data'
 import { useStorageCache } from '../hooks/useStorage'
 import { RoutesParams } from '../navigation/NavigationTypes'
-import { getLabels } from '../services/helpers'
 import { reportError } from '../services/sentry'
 import { setExerciseProgress } from '../services/storageUtils'
 
@@ -42,7 +41,7 @@ const VocabularyListScreen = ({ route, navigation }: VocabularyListScreenProps):
       <VocabularyList
         vocabularyItems={route.params.vocabularyItems}
         onItemPress={onItemPress}
-        title={getLabels().exercises.vocabularyList.title}
+        title={route.params.unitTitle}
       />
     </RouteWrapper>
   )

--- a/src/routes/__tests__/VocabularyListScreen.spec.tsx
+++ b/src/routes/__tests__/VocabularyListScreen.spec.tsx
@@ -56,7 +56,7 @@ describe('VocabularyListScreen', () => {
       <VocabularyListScreen route={route} navigation={navigation} />,
     )
 
-    expect(getByText(getLabels().exercises.vocabularyList.title)).toBeTruthy()
+    expect(getByText('My unit title')).toBeTruthy()
     expect(getByText(`2 ${getLabels().general.word.plural}`)).toBeTruthy()
     expect(getByText('der')).toBeTruthy()
     expect(getByText('Spachtel')).toBeTruthy()


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR puts the name of the current unit as the title of the vocabulary list, as opposed to "Wortliste"

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open a word list exercise

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1352 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
