### PR TITLE
1387: Remove react-native-image-zoom-viewer

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,5 @@
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock'
 import '@testing-library/jest-native/extend-expect'
-import { Component } from 'react'
 // @ts-expect-error file is js
 import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
 import 'react-native-gesture-handler/jestSetup'
@@ -34,44 +33,6 @@ jest.mock('react-native-volume-manager', () => ({
 jest.mock('react-native/Libraries/Image/ImageBackground', () => {
   const { View } = require('react-native')
   return { __esModule: true, default: View }
-})
-
-jest.mock('react-native-image-zoom-viewer', () => {
-  const React = require('react')
-  const { View } = require('react-native')
-
-  class ImageViewerMock extends Component<{
-    imageUrls: { url: string }[]
-    renderImage?: (item: { source: { uri: string } }) => React.ReactElement
-    renderIndicator?: (currentIndex: number, allSize: number) => React.ReactElement
-    backgroundColor?: string
-  }> {
-    private currentIndex = 0
-    // eslint-disable-next-line react/no-unused-class-component-methods
-    loadImage(index: number) {
-      this.currentIndex = index
-      this.forceUpdate()
-    }
-    // eslint-disable-next-line react/no-unused-class-component-methods
-    goNext() {
-      this.currentIndex += 1
-      this.forceUpdate()
-    }
-    render() {
-      const { imageUrls, renderImage, renderIndicator, backgroundColor } = this.props
-      return React.createElement(
-        View,
-        { style: { flex: 1, backgroundColor } },
-        imageUrls.map((url: { url: string }, i: number) =>
-          i <= this.currentIndex
-            ? React.createElement(View, { key: url.url }, renderImage?.({ source: { uri: url.url } }))
-            : React.createElement(View, { key: url.url }),
-        ),
-        renderIndicator?.(this.currentIndex + 1, imageUrls.length),
-      )
-    }
-  }
-  return { __esModule: true, default: ImageViewerMock }
 })
 
 jest.mock('@sentry/react-native', () => ({

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.28.0",
     "react-native-image-picker": "^8.2.1",
-    "react-native-image-zoom-viewer": "^3.0.1",
     "react-native-nitro-modules": "^0.34.1",
     "react-native-nitro-sound": "^0.2.10",
     "react-native-pager-view": "^8.0.0",

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -1,24 +1,21 @@
-import React, { ReactElement } from 'react'
-import { Keyboard, useWindowDimensions } from 'react-native'
-import ImageViewer from 'react-native-image-zoom-viewer'
+import React, { ReactElement, useState } from 'react'
+import { useWindowDimensions, View } from 'react-native'
+import PagerView, { PagerViewOnPageSelectedEvent } from 'react-native-pager-view'
 import styled, { useTheme } from 'styled-components/native'
 
-const ImageView = styled.View<{ height: number }>`
+const VIEWER_HEIGHT_PERCENT = 0.35
+
+const ImageViewContainer = styled.View<{ height: number }>`
   height: ${({ height }) => height}px;
-`
-const StyledImage = styled.Image<{ height: number; minimized: boolean }>`
-  height: ${({ height }) => height}px;
-  /* center image because resizeMode doesn't work for ios */
-  ${({ minimized }) =>
-    minimized &&
-    `
-    aspect-ratio: 1.5;
-    margin: 0 auto;
-  `}
 `
 
-const minimizedPosition = -10
-const normalPosition = 10
+const StyledPagerView = styled(PagerView)`
+  flex: 1;
+  background-color: ${props => props.theme.colors.backgroundAccent};
+`
+const StyledImage = styled.Image`
+  height: 100%;
+`
 
 const Dot = styled.View`
   height: 5px;
@@ -34,70 +31,49 @@ const ActiveDot = styled(Dot)`
   background-color: ${props => props.theme.colors.textSecondary};
 `
 
-const PaginationView = styled.View<{ minimized: boolean }>`
+const IndicatorView = styled.View`
   width: 100%;
   position: absolute;
-  display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  top: ${({ minimized }) => (minimized ? minimizedPosition : normalPosition)}px;
+  top: ${props => props.theme.spacings.xs};
 `
 
 type ImageCarouselProps = {
   images: string[]
-  minimized?: boolean
 }
 
-type Item = {
-  source: {
-    uri: string
-  }
-}
-
-type ImageUrl = {
-  url: string
-}
-
-const ImageCarousel = ({ images, minimized = false }: ImageCarouselProps): ReactElement => {
+const ImageCarousel = ({ images }: ImageCarouselProps): ReactElement => {
+  const [currentPage, setCurrentPage] = useState(0)
   const theme = useTheme()
   const { height: deviceHeight } = useWindowDimensions()
-  // Manually resize ImageViewer since it doesn't happen automatically on container size changes
-  const height = 35
-  const percentage = 100
-  const heightPercent = minimized ? height / 2 : height
-  const viewerHeight = (deviceHeight * heightPercent) / percentage
+  const viewerHeight = deviceHeight * VIEWER_HEIGHT_PERCENT
 
-  const imagesUrls: ImageUrl[] = images.map(image => ({
-    url: image,
-  }))
+  const onPageSelected = (event: PagerViewOnPageSelectedEvent): void => {
+    setCurrentPage(event.nativeEvent.position)
+  }
 
-  const renderIndicator = (currentIndex?: number, allSize?: number): ReactElement => (
-    <PaginationView minimized={minimized}>
-      {!!allSize &&
-        !!currentIndex &&
-        allSize > 1 &&
-        imagesUrls.map((item, index) =>
-          index + 1 === currentIndex ? <ActiveDot key={item.url} /> : <Dot key={item.url} />,
-        )}
-    </PaginationView>
+  const indicator = (
+    <IndicatorView>
+      {images.length > 1 &&
+        images.map((url, index) => (index === currentPage ? <ActiveDot key={url} /> : <Dot key={url} />))}
+    </IndicatorView>
   )
 
-  const renderItem = (item: Item): ReactElement => (
-    <StyledImage source={item.source} minimized={minimized} height={viewerHeight} testID='image' />
+  const renderItem = (url: string): ReactElement => (
+    <View key={url}>
+      <StyledImage src={url} testID='image' resizeMode='contain' />
+    </View>
   )
 
   return (
-    <ImageView testID='Swipeable' height={viewerHeight}>
-      <ImageViewer
-        key={imagesUrls.map(elem => elem.url).join()}
-        imageUrls={imagesUrls}
-        renderImage={renderItem}
-        renderIndicator={renderIndicator}
-        backgroundColor={theme.colors.backgroundAccent}
-        onClick={Keyboard.dismiss}
-      />
-    </ImageView>
+    <ImageViewContainer height={viewerHeight}>
+      <StyledPagerView initialPage={0} onPageSelected={onPageSelected} pageMargin={theme.spacingsPlain.sm}>
+        {images.map(renderItem)}
+      </StyledPagerView>
+      {indicator}
+    </ImageViewContainer>
   )
 }
 

--- a/src/components/VocabularyItemImageSection.tsx
+++ b/src/components/VocabularyItemImageSection.tsx
@@ -28,7 +28,6 @@ type VocabularyItemSectionProps = {
   vocabularyItem: VocabularyItem
   audioDisabled?: boolean
   showAudioPlayer?: boolean
-  minimized?: boolean
   submittedAlternative?: string | null
 }
 
@@ -36,11 +35,10 @@ const VocabularyItemImageSection = ({
   vocabularyItem,
   audioDisabled = false,
   showAudioPlayer = true,
-  minimized = false,
   submittedAlternative,
 }: VocabularyItemSectionProps): ReactElement => (
   <Container>
-    <ImageCarousel images={vocabularyItem.images} minimized={minimized} />
+    <ImageCarousel images={vocabularyItem.images} />
     {showAudioPlayer && (
       <AudioContainer>
         <AudioPlayer

--- a/src/components/__tests__/ImageCarousel.spec.tsx
+++ b/src/components/__tests__/ImageCarousel.spec.tsx
@@ -1,48 +1,17 @@
-import { act } from '@testing-library/react-native'
 import React from 'react'
-import { ReactTestInstance } from 'react-test-renderer'
 
 import render from '../../testing/render'
 import ImageCarousel from '../ImageCarousel'
 
-jest.mock('react-native/Libraries/Image/Image', () => ({
-  ...jest.requireActual('react-native/Libraries/Image/Image'),
-  getSize: (uri: string, success: (w: number, h: number) => void) => {
-    success(1234, 1234)
-  },
-}))
-
 describe('ImageCarousel', () => {
   const images = ['Arbeitshose', 'Arbeitsschuhe']
 
-  const getUri = (image: ReactTestInstance): string => image.props.source[0].uri
-
-  it('should display the images', async () => {
-    const { getByTestId, getAllByTestId } = render(<ImageCarousel images={images} />)
-
-    const row = getByTestId('Swipeable')
-    expect(row).toBeTruthy()
-    const swipeable = row.children[0] as ReactTestInstance
+  it('should display all images', () => {
+    const { getAllByTestId } = render(<ImageCarousel images={images} />)
 
     const displayedImages = getAllByTestId('image')
-    expect(displayedImages).toHaveLength(1)
-
-    const firstImage = displayedImages[0]
-    expect(getUri(firstImage)).toBe('Arbeitshose')
-
-    // the react-native-image-zoom library renders the images in a row next to each other
-    // images which were not yet loaded don't have a size and are therefore only rendered as an empty View
-    // swiping to the next image triggers loadImage and goNext, but we only care about loadImage
-    // as the image is then rendered and accessible by role, even without swiping
-    await act(async () => swipeable.instance.loadImage(1)) // load the second image
-
-    const swipedDisplayedImages = getAllByTestId('image')
-    expect(swipedDisplayedImages).toHaveLength(2)
-
-    const swipedFirstImage = swipedDisplayedImages[0]
-    expect(swipedFirstImage).toBe(firstImage)
-
-    const secondImage = swipedDisplayedImages[1]
-    expect(getUri(secondImage)).toBe('Arbeitsschuhe')
+    expect(displayedImages).toHaveLength(2)
+    expect(displayedImages[0].props.src).toBe('Arbeitshose')
+    expect(displayedImages[1].props.src).toBe('Arbeitsschuhe')
   })
 })

--- a/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
+++ b/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
@@ -35,11 +35,6 @@ jest.mock('../../../components/AudioPlayer', () => {
   return () => <Text>AudioPlayer</Text>
 })
 
-jest.mock('react-native-image-zoom-viewer', () => {
-  const Text = require('react-native').Text
-  return () => <Text>ImageZoomViewer</Text>
-})
-
 // The bottom sheet is difficult to test due to its animations
 jest.mock(
   '../../../components/BottomSheet',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8499,7 +8499,6 @@ __metadata:
     react-native-fs: ^2.20.0
     react-native-gesture-handler: ^2.28.0
     react-native-image-picker: ^8.2.1
-    react-native-image-zoom-viewer: ^3.0.1
     react-native-nitro-modules: ^0.34.1
     react-native-nitro-sound: ^0.2.10
     react-native-pager-view: ^8.0.0
@@ -9950,16 +9949,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-image-pan-zoom@npm:^2.1.12":
-  version: 2.1.12
-  resolution: "react-native-image-pan-zoom@npm:2.1.12"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: c1047da6b7eb0d8a80a810eba8dc0c74e11d0b476808c30d1bbc6285c3f8dc8140aba60fb1af35e2c8c114aa32eed64fb545214a6cf1c00d6b80dd3178bdf3f6
-  languageName: node
-  linkType: hard
-
 "react-native-image-picker@npm:^8.2.1":
   version: 8.2.1
   resolution: "react-native-image-picker@npm:8.2.1"
@@ -9967,18 +9956,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 82b6c51ece8d16806975aff7675d26280fdd2391c05ca9415620195cc6643ca0db4601d3b24e117d7f5331c2e55ba7c03090d276e55b3b5687a636245428a047
-  languageName: node
-  linkType: hard
-
-"react-native-image-zoom-viewer@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "react-native-image-zoom-viewer@npm:3.0.1"
-  dependencies:
-    react-native-image-pan-zoom: ^2.1.12
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: d7ee6ea947a10061b3b285622416dececda72be6907cfe5ab4a2680dcecb51f32adf1d250d1ce12c87178cb8c8a92d85cba89acde437ae4730e36f8e6152455b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
It was decided that the niche functionality of zooming is not worth keeping a deprecated library.
To re-implement the pager functionality, this pr uses the already existing library `react-native-pager-view`.
Also removes the `minimized` prop to the image carousel. I don't know what it was used for.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the library
- Use the pager library to re-implement the swiping functionality
- Remove unused `minimized` prop

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I changed the image resize mode to 'contain', from 'cover' so that images are not cut off, which might cause some more edges. If this is not wanted, I can revert that change.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that images are still shown and that swiping still works. The simplest way to do so is to create a custom word with multiple images or to find a training exercise where the cms returns multiple images for a single word.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1387

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
