### PR TITLE
1404: Use distinct package id for debug builds on android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,6 +111,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            applicationIdSuffix = ".debug"
         }
         release {
             // Caution! In production, you need to generate your own keystore file.

--- a/android/app/src/debug/res/values/ic_launcher_background.xml
+++ b/android/app/src/debug/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#360050</color>
+</resources>

--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Lunes (Debug)</string>
+</resources>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "yarn@3.2.2",
   "scripts": {
-    "android": "react-native run-android --no-packager --active-arch-only",
+    "android": "react-native run-android --no-packager --active-arch-only --appIdSuffix debug",
     "android:production": "react-native run-android --no-packager --mode=release",
     "ios": "react-native run-ios",
     "start": "react-native start",


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This enables installation alongside the production version of lunes to make it easier to debug on personal devices.
Also changes the name to Lunes (Debug) and adds a slight tint to the icon so that the different build variants can be distinguished more easily.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add a suffix to the package id so that android treats the debug builds as a distinct app to the release build
- Change the name and icon of debug builds so that they won't be confused with a potential existing production installation of lunes

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This does not change anything on ios, because I don't know if such a problem also exists on iOS. @LeandraH do you have an opinion on this?

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1404 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
