### PR TITLE
Fix the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,7 +688,7 @@ workflows:
                     - check
                     - bump_version
         when:
-            or:
+            and:
                 - << pipeline.parameters.run_commit >>
                 - equal:
                     - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,7 +688,7 @@ workflows:
                     - check
                     - bump_version
         when:
-            and:
+            or:
                 - << pipeline.parameters.run_commit >>
                 - equal:
                     - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
         steps:
             - add_ssh_keys:
                 fingerprints:
-                    - 24:1d:3b:b7:b3:49:69:d7:54:c3:93:a5:a2:d1:71:db
+                    - aa:6c:35:24:8a:80:d8:6a:f3:d7:b1:b3:49:42:a2:b3
             - checkout
             - restore_ruby_cache:
                 directory: android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
         steps:
             - add_ssh_keys:
                 fingerprints:
-                    - 24:1d:3b:b7:b3:49:69:d7:54:c3:93:a5:a2:d1:71:db
+                    - aa:6c:35:24:8a:80:d8:6a:f3:d7:b1:b3:49:42:a2:b3
             - checkout
             - prepare_workspace
             - restore_environment_variables

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -8,7 +8,7 @@ shell: /bin/bash -eo pipefail
 steps:
   - add_ssh_keys: # Needed for credentials repo
       fingerprints:
-        - 24:1d:3b:b7:b3:49:69:d7:54:c3:93:a5:a2:d1:71:db
+        - aa:6c:35:24:8a:80:d8:6a:f3:d7:b1:b3:49:42:a2:b3
   - checkout
   - restore_ruby_cache:
       directory: android

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -9,7 +9,7 @@ shell: /bin/bash --login -o pipefail
 steps:
   - add_ssh_keys: # Needed for credentials repo
       fingerprints:
-        - 24:1d:3b:b7:b3:49:69:d7:54:c3:93:a5:a2:d1:71:db
+        - aa:6c:35:24:8a:80:d8:6a:f3:d7:b1:b3:49:42:a2:b3
   - checkout
   - prepare_workspace
   - restore_environment_variables

--- a/.circleci/src/workflows/commit_main.yml
+++ b/.circleci/src/workflows/commit_main.yml
@@ -1,5 +1,5 @@
 when:
-  and:
+  or:
     - << pipeline.parameters.run_commit >>
     - equal: [main, << pipeline.git.branch >>]
 jobs:

--- a/.circleci/src/workflows/commit_main.yml
+++ b/.circleci/src/workflows/commit_main.yml
@@ -1,5 +1,5 @@
 when:
-  or:
+  and:
     - << pipeline.parameters.run_commit >>
     - equal: [main, << pipeline.git.branch >>]
 jobs:


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The CI broke last week, because the runner was no longer able to access our private app signing repository.
The reason for that appears to be that there is a mismatch between the key that we configured at [circle ci](https://app.circleci.com/settings/project/github/digitalfabrik/lunes-app/ssh) (Section "Additional SSH Keys") and the fingerprint expected in our circle ci .yml files.
I have no idea why we suddenly have this mismatch since last week (First failing commit is 3586bf6da9af52489e07bd17169d5014cbe03124 on April 15th). The only explanation I can think of is that someone modified the circle ci key for some reason without notifying us about that?

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update the expected fingerprint with the fingerprint of the key specified in circle ci

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
I ran a commit_main workflow for this pr which completed successfully: https://app.circleci.com/pipelines/github/digitalfabrik/lunes-app/4543/workflows/31568908-3fa4-4b40-9fe4-4495bf148ad6

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: our ci

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
