### PR TITLE
Fix color of settings icon in header

### DIFF
--- a/src/routes/home/components/HomeScreenHeader.tsx
+++ b/src/routes/home/components/HomeScreenHeader.tsx
@@ -15,16 +15,14 @@ const SmileIconStyle = styled.Pressable`
   bottom: -${props => props.theme.spacings.xxl};
 `
 
-const HeaderButtonsContainer = styled.View`
-  align-self: flex-end;
-`
-
 const MenuIconContainer = styled.TouchableOpacity`
+  align-self: flex-end;
   padding: ${props => props.theme.spacings.sm} ${props => props.theme.spacings.xxs};
 `
 
 const MenuIconWhite = styled(MenuIcon)`
   padding: 0 ${props => props.theme.spacings.md};
+  color: ${props => props.theme.colors.backgroundAccent};
 `
 
 type HomeScreenHeaderProps = {
@@ -36,11 +34,9 @@ const HomeScreenHeader = ({ navigation }: HomeScreenHeaderProps): ReactElement =
     <SmileIconStyle>
       <LunesIcon width={96} height={96} />
     </SmileIconStyle>
-    <HeaderButtonsContainer>
-      <MenuIconContainer onPress={() => navigation.navigate('OverlayMenu')}>
-        <MenuIconWhite testID='menu-icon-white' />
-      </MenuIconContainer>
-    </HeaderButtonsContainer>
+    <MenuIconContainer onPress={() => navigation.navigate('OverlayMenu')}>
+      <MenuIconWhite testID='menu-icon-white' />
+    </MenuIconContainer>
   </Wrapper>
 )
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Sorry, I apparently deleted the color of the settings icon during my recent styling updates. This puts it back in, so that you have a white settings wheel on a dark blue background, instead of a black one on a dark blue background.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open the app and see that you can see the settings wheel

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
