### PR TITLE
1261: Add tracking for repetition of exercises

### DIFF
--- a/src/hooks/__tests__/useTrackExerciseRepetition.spec.ts
+++ b/src/hooks/__tests__/useTrackExerciseRepetition.spec.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react-native'
+
+import { ExerciseKeys } from '../../constants/data'
+import { StandardUnitId } from '../../models/Unit'
+import { trackEvent } from '../../services/AnalyticsService'
+import useTrackExerciseRepetition from '../useTrackExerciseRepetition'
+
+jest.mock('../../services/AnalyticsService', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('../../services/SessionService', () => ({
+  getCurrentSessionId: jest.fn(() => 'test-session-id'),
+}))
+
+jest.mock('../useStorage', () => ({
+  useStorageCache: jest.fn(() => 'mockStorageCache'),
+}))
+
+const unitId: StandardUnitId = { type: 'standard', id: 42 }
+
+describe('useTrackExerciseRepetition', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should track exercise_repetition event on mount', () => {
+    renderHook(() => useTrackExerciseRepetition(ExerciseKeys.wordChoiceExercise, unitId))
+
+    expect(trackEvent).toHaveBeenCalledWith('mockStorageCache', {
+      type: 'exercise_repetition',
+      exercise_type: ExerciseKeys.wordChoiceExercise,
+      unit_id: 42,
+      session_id: 'test-session-id',
+    })
+    expect(trackEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('should count each exercise screen entry once', () => {
+    const { rerender } = renderHook(() => useTrackExerciseRepetition(ExerciseKeys.wordChoiceExercise, unitId))
+    rerender({})
+
+    expect(trackEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not track an event without a unit id', () => {
+    renderHook(() => useTrackExerciseRepetition(ExerciseKeys.wordChoiceExercise, null))
+
+    expect(trackEvent).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/__tests__/useTrackSession.spec.ts
+++ b/src/hooks/__tests__/useTrackSession.spec.ts
@@ -2,12 +2,17 @@ import { act, renderHook } from '@testing-library/react-native'
 import { mocked } from 'jest-mock'
 import { AppState, AppStateStatus } from 'react-native'
 
-import { generateUniqueId, trackEvent } from '../../services/AnalyticsService'
+import { trackEvent } from '../../services/AnalyticsService'
+import { getCurrentSessionId, rotateSessionId } from '../../services/SessionService'
 import useTrackSession from '../useTrackSession'
 
 jest.mock('../../services/AnalyticsService', () => ({
   trackEvent: jest.fn(),
-  generateUniqueId: jest.fn(() => 'session-1'),
+}))
+
+jest.mock('../../services/SessionService', () => ({
+  getCurrentSessionId: jest.fn(() => 'session-1'),
+  rotateSessionId: jest.fn(),
 }))
 
 jest.mock('../useStorage', () => ({
@@ -55,8 +60,12 @@ describe('useTrackSession', () => {
     })
   })
 
-  it('should track session_end and generate new session ID when transitioning to background', () => {
-    mocked(generateUniqueId).mockReturnValueOnce('session-1').mockReturnValueOnce('session-2')
+  it('should track session_end and rotate session ID when transitioning to background', () => {
+    mocked(getCurrentSessionId)
+      .mockReturnValueOnce('session-1')
+      .mockReturnValueOnce('session-1')
+      .mockReturnValueOnce('session-2')
+      .mockReturnValueOnce('session-2')
     AppState.currentState = 'active'
     renderHook(useTrackSession)
 
@@ -69,6 +78,7 @@ describe('useTrackSession', () => {
       type: 'session_end',
       session_id: 'session-1',
     })
+    expect(rotateSessionId).toHaveBeenCalledTimes(1)
     act(() => changeHandler!('active'))
     expect(trackEvent).toHaveBeenCalledWith('mockStorageCache', {
       type: 'session_start',
@@ -79,6 +89,7 @@ describe('useTrackSession', () => {
       type: 'session_end',
       session_id: 'session-2',
     })
+    expect(rotateSessionId).toHaveBeenCalledTimes(2)
   })
 
   it('should ignore inactive state changes', () => {

--- a/src/hooks/useTrackExerciseRepetition.ts
+++ b/src/hooks/useTrackExerciseRepetition.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+import { ExerciseKey } from '../constants/data'
+import { StandardUnitId } from '../models/Unit'
+import { trackEvent } from '../services/AnalyticsService'
+import { getCurrentSessionId } from '../services/SessionService'
+import { useStorageCache } from './useStorage'
+
+const useTrackExerciseRepetition = (exerciseType: ExerciseKey, unitId: StandardUnitId | null): void => {
+  const storageCache = useStorageCache()
+
+  useEffect(() => {
+    if (unitId === null) {
+      return
+    }
+    trackEvent(storageCache, {
+      type: 'exercise_repetition',
+      exercise_type: exerciseType,
+      unit_id: unitId.id,
+      session_id: getCurrentSessionId(),
+    })
+  }, [storageCache, exerciseType, unitId])
+}
+
+export default useTrackExerciseRepetition

--- a/src/hooks/useTrackSession.ts
+++ b/src/hooks/useTrackSession.ts
@@ -1,13 +1,13 @@
 import { useEffect, useRef } from 'react'
 import { AppState, AppStateStatus } from 'react-native'
 
-import { generateUniqueId, trackEvent } from '../services/AnalyticsService'
+import { trackEvent } from '../services/AnalyticsService'
+import { getCurrentSessionId, rotateSessionId } from '../services/SessionService'
 import { useStorageCache } from './useStorage'
 
 const useTrackSession = (): void => {
   const storageCache = useStorageCache()
   const appState = useRef<'active' | 'background'>('background')
-  const sessionIdRef = useRef(generateUniqueId())
 
   useEffect(() => {
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
@@ -17,10 +17,10 @@ const useTrackSession = (): void => {
       const previousState = appState.current
       appState.current = nextAppState
       if (nextAppState === 'active' && previousState === 'background') {
-        trackEvent(storageCache, { type: 'session_start', session_id: sessionIdRef.current })
+        trackEvent(storageCache, { type: 'session_start', session_id: getCurrentSessionId() })
       } else if (nextAppState === 'background' && previousState === 'active') {
-        trackEvent(storageCache, { type: 'session_end', session_id: sessionIdRef.current })
-        sessionIdRef.current = generateUniqueId()
+        trackEvent(storageCache, { type: 'session_end', session_id: getCurrentSessionId() })
+        rotateSessionId()
       }
     }
 

--- a/src/routes/VocabularyListScreen.tsx
+++ b/src/routes/VocabularyListScreen.tsx
@@ -7,6 +7,7 @@ import RouteWrapper from '../components/RouteWrapper'
 import VocabularyList from '../components/VocabularyList'
 import { ExerciseKeys } from '../constants/data'
 import { useStorageCache } from '../hooks/useStorage'
+import useTrackExerciseRepetition from '../hooks/useTrackExerciseRepetition'
 import useTrackMountDuration from '../hooks/useTrackMountDuration'
 import { RoutesParams } from '../navigation/NavigationTypes'
 import { trackEvent } from '../services/AnalyticsService'
@@ -23,6 +24,7 @@ const VocabularyListScreen = ({ route, navigation }: VocabularyListScreenProps):
   const unitId = contentType === 'standard' ? route.params.unitId : null
   const storageCache = useStorageCache()
 
+  useTrackExerciseRepetition(ExerciseKeys.vocabularyList, unitId)
   useTrackMountDuration(durationSeconds => {
     if (unitId !== null) {
       trackEvent(storageCache, {

--- a/src/routes/__tests__/VocabularyListScreen.spec.tsx
+++ b/src/routes/__tests__/VocabularyListScreen.spec.tsx
@@ -33,6 +33,10 @@ jest.mock('../../services/AnalyticsService', () => ({
   trackEvent: jest.fn(),
 }))
 
+jest.mock('../../services/SessionService', () => ({
+  getCurrentSessionId: jest.fn(() => 'test-session-id'),
+}))
+
 describe('VocabularyListScreen', () => {
   const vocabularyItems = new VocabularyItemBuilder(2).build()
   const route: RouteProp<RoutesParams, 'VocabularyList'> = {
@@ -83,7 +87,7 @@ describe('VocabularyListScreen', () => {
       <VocabularyListScreen route={route} navigation={navigation} />,
     )
 
-    expect(trackEvent).not.toHaveBeenCalled()
+    expect(trackEvent).not.toHaveBeenCalledWith(storageCache, expect.objectContaining({ type: 'module_duration' }))
     unmount()
     expect(trackEvent).toHaveBeenCalledWith(storageCache, {
       type: 'module_duration',

--- a/src/routes/choice-exercises/WordChoiceExerciseScreen.tsx
+++ b/src/routes/choice-exercises/WordChoiceExerciseScreen.tsx
@@ -5,6 +5,7 @@ import React, { ReactElement } from 'react'
 import RouteWrapper from '../../components/RouteWrapper'
 import { ExerciseKeys } from '../../constants/data'
 import { useStorageCache } from '../../hooks/useStorage'
+import useTrackExerciseRepetition from '../../hooks/useTrackExerciseRepetition'
 import useTrackMountDuration from '../../hooks/useTrackMountDuration'
 import { RoutesParams } from '../../navigation/NavigationTypes'
 import { trackEvent } from '../../services/AnalyticsService'
@@ -21,6 +22,7 @@ const WordChoiceExerciseScreen = ({ navigation, route }: WordChoiceExerciseScree
   const isRepetitionExercise = contentType === 'repetition'
 
   const storageCache = useStorageCache()
+  useTrackExerciseRepetition(ExerciseKeys.wordChoiceExercise, unitId)
   useTrackMountDuration(durationSeconds => {
     if (unitId !== null) {
       trackEvent(storageCache, {

--- a/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
+++ b/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
@@ -55,6 +55,10 @@ jest.mock('../../../services/AnalyticsService', () => ({
   trackEvent: jest.fn(),
 }))
 
+jest.mock('../../../services/SessionService', () => ({
+  getCurrentSessionId: jest.fn(() => 'test-session-id'),
+}))
+
 describe('WordChoiceExerciseScreen', () => {
   // at least 4 vocabularyItems are needed to generate sufficient false answers
   const vocabularyItems = new VocabularyItemBuilder(4).build()
@@ -242,7 +246,7 @@ describe('WordChoiceExerciseScreen', () => {
   it('should track module duration on unmount', () => {
     const { unmount } = renderScreen()
 
-    expect(trackEvent).not.toHaveBeenCalled()
+    expect(trackEvent).not.toHaveBeenCalledWith(storageCache, expect.objectContaining({ type: 'module_duration' }))
     unmount()
     expect(trackEvent).toHaveBeenCalledWith(storageCache, {
       type: 'module_duration',

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -42,6 +42,12 @@ export type AnalyticsPayload =
       position: number
       total: number
     }
+  | {
+      type: 'exercise_repetition'
+      exercise_type: ExerciseKey
+      unit_id: number
+      session_id: string
+    }
 
 export const isConsentGiven = (storageCache: StorageCache): boolean => {
   const consent = storageCache.getItem('analyticsConsent')

--- a/src/services/SessionService.ts
+++ b/src/services/SessionService.ts
@@ -1,0 +1,12 @@
+import { generateUniqueId } from './AnalyticsService'
+
+let currentSessionId: string | null = null
+
+export const getCurrentSessionId = (): string => {
+  currentSessionId ??= generateUniqueId()
+  return currentSessionId
+}
+
+export const rotateSessionId = (): void => {
+  currentSessionId = generateUniqueId()
+}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR adds tracking for repeating exercises

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Send a tracking event to the CMS whenever an exercise is started (they are aggregated and counted in the CMS)
- Pull the management of the session ID into a separate helper function (it was only used inside the session tracking hook before)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Probably still against a local CMS running develop, start an exercise (word list or word choice), go into the settings to see your tracked events, see the repetition event

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1261 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
