### PR TITLE
Hotfix: Fix white screen on restart

### DIFF
--- a/src/services/__tests__/storageUtils.spec.ts
+++ b/src/services/__tests__/storageUtils.spec.ts
@@ -452,6 +452,54 @@ describe('storageUtils', () => {
         })
       })
     })
+
+    describe('when version is unset and data is already fully migrated', () => {
+      const alreadyMigratedWordNodeCard = {
+        wordId: { type: VocabularyItemTypes.Standard, id: 1 },
+        section: 2,
+        inThisSectionSince: new Date('2025-10-13').toISOString(),
+      }
+
+      const alreadyMigratedUserVocabularyItem = {
+        id: { index: 1, type: VocabularyItemTypes.UserCreated },
+        word: 'Hund',
+        article: { id: 1, value: 'der' },
+        images: ['image-1'],
+        audio: null,
+        alternatives: [],
+      }
+
+      const alreadyMigratedFavorite: Favorite = { id: 1, type: VocabularyItemTypes.Standard }
+
+      beforeEach(async () => {
+        // No version key — simulates fresh installs that never wrote the version.
+        await AsyncStorage.setItem(storageKeys.selectedJobs, JSON.stringify([1]))
+      })
+
+      it('should pass through wordNodeCards unchanged', async () => {
+        await AsyncStorage.setItem('wordNodeCards', JSON.stringify([alreadyMigratedWordNodeCard]))
+
+        const storageCache = await loadStorageCache()
+
+        expect(storageCache.getItem('wordNodeCards')).toEqual([alreadyMigratedWordNodeCard])
+      })
+
+      it('should pass through userVocabulary unchanged', async () => {
+        await AsyncStorage.setItem('userVocabulary', JSON.stringify([alreadyMigratedUserVocabularyItem]))
+
+        const storageCache = await loadStorageCache()
+
+        expect(storageCache.getItem('userVocabulary')).toEqual([alreadyMigratedUserVocabularyItem])
+      })
+
+      it('should pass through favorites unchanged', async () => {
+        await AsyncStorage.setItem('favorites-2', JSON.stringify([alreadyMigratedFavorite]))
+
+        const storageCache = await loadStorageCache()
+
+        expect(storageCache.getItem('favorites')).toEqual([alreadyMigratedFavorite])
+      })
+    })
   })
 
   describe('userVocabulary', () => {

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -250,7 +250,7 @@ export const migrate3To4 = async (): Promise<void> => {
 // Replaces full VocabularyItem stored in WordNodeCards with only the VocabularyItemId
 export const migrate4To5 = async (): Promise<void> => {
   type OldWordNodeCard = {
-    word: { id: VocabularyItemId }
+    word?: { id: VocabularyItemId }
     section: WordNodeCard['section']
     inThisSectionSince: string
   }
@@ -261,11 +261,13 @@ export const migrate4To5 = async (): Promise<void> => {
     inThisSectionSince: Date
   }
 
-  const migrateCard = ({ word, section, inThisSectionSince }: OldWordNodeCard): NewWordNodeCard => ({
-    wordId: word.id,
-    section,
-    inThisSectionSince: new Date(inThisSectionSince),
-  })
+  const migrateCard = (card: OldWordNodeCard): NewWordNodeCard => {
+    if (card.word === undefined) {
+      // Card is already in the new format (was migrated in a previous app launch)
+      return card as unknown as NewWordNodeCard
+    }
+    return { wordId: card.word.id, section: card.section, inThisSectionSince: new Date(card.inThisSectionSince) }
+  }
 
   const oldCards = await getStorageItemOr<OldWordNodeCard[]>('wordNodeCards', [])
   const newCards = oldCards.map(migrateCard)
@@ -339,9 +341,7 @@ export const migrateStorage = async (): Promise<void> => {
     await migrateApiEndpointUrl()
   }
 
-  if (lastVersion !== STORAGE_VERSION) {
-    await AsyncStorage.setItem('version', STORAGE_VERSION.toString())
-  }
+  await AsyncStorage.setItem('version', STORAGE_VERSION.toString())
 }
 
 export const isFavorite = (favorites: readonly Favorite[], favorite: Favorite): boolean =>

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -133,19 +133,25 @@ export const migrate0To1 = async (): Promise<void> => {
 // Migrates the `images` field of `VocabularyItem` to a flat array of urls
 export const migrate1To2 = async (): Promise<void> => {
   type OldVocabularyItem = Incomplete<{ images: { image: string }[] }>
-  type OldWordNodeCard = Incomplete<{ word: OldVocabularyItem }>
+  type OldWordNodeCard = Incomplete<{ word?: OldVocabularyItem }>
 
-  const updateVocabularyItem = (oldWord: OldVocabularyItem): Incomplete<{ images: string[] }> => ({
-    ...oldWord,
-    images: oldWord.images.map(image => image.image),
-  })
+  const updateVocabularyItem = (oldWord: OldVocabularyItem): Incomplete<{ images: string[] }> => {
+    const firstImage = oldWord.images[0]
+    if (firstImage === undefined || typeof firstImage === 'string') {
+      // Images are already a flat string array (migrated in a previous app launch)
+      return oldWord as unknown as Incomplete<{ images: string[] }>
+    }
+    return { ...oldWord, images: oldWord.images.map(image => image.image) }
+  }
 
   const oldUserVocabulary = await getStorageItemOr<OldVocabularyItem[]>('userVocabulary', [])
   const newUserVocabulary = oldUserVocabulary.map(updateVocabularyItem)
   await AsyncStorage.setItem('userVocabulary', JSON.stringify(newUserVocabulary))
 
   const oldWordNodeCards = await getStorageItemOr<OldWordNodeCard[]>('wordNodeCards', [])
-  const newWordNodeCards = oldWordNodeCards.map(card => ({ ...card, word: updateVocabularyItem(card.word) }))
+  const newWordNodeCards = oldWordNodeCards.map(card =>
+    card.word === undefined ? card : { ...card, word: updateVocabularyItem(card.word) },
+  )
   await AsyncStorage.setItem('wordNodeCards', JSON.stringify(newWordNodeCards))
 }
 
@@ -201,11 +207,15 @@ export const migrate2To3 = async (): Promise<void> => {
 
   const migrateWordNodeCards = async (): Promise<void> => {
     type OldWordNodeCard = Incomplete<{
-      word: OldVocabularyItem
+      word?: OldVocabularyItem
     }>
     type NewWordNodeCard = Incomplete<{ word: Incomplete<{ id: NewVocabularyId }> }>
 
     const updateWordNodeCard = (oldWordNodeCard: OldWordNodeCard): NewWordNodeCard | null => {
+      if (oldWordNodeCard.word === undefined) {
+        // Card is already in the newer format (was migrated in a previous app launch)
+        return oldWordNodeCard as unknown as NewWordNodeCard
+      }
       const newId = getNewId(oldWordNodeCard.word)
       if (newId === null) {
         return null
@@ -225,13 +235,19 @@ export const migrate2To3 = async (): Promise<void> => {
   const migrateFavorites = async (): Promise<void> => {
     type OldFavorite = {
       id: number
-      vocabularyItemType: OldVocabularyItemType
+      vocabularyItemType?: OldVocabularyItemType
       apiKey?: string
     }
 
     const oldFavorites = await getStorageItemOr<OldFavorite[]>('favorites-2', [])
     const newFavorites: NewVocabularyId[] = oldFavorites
-      .map(({ id, vocabularyItemType, apiKey }) => getNewId({ id, type: vocabularyItemType, apiKey }))
+      .map(favorite => {
+        if (favorite.vocabularyItemType === undefined) {
+          // Favorite is already in the new format (was migrated in a previous app launch)
+          return favorite as unknown as NewVocabularyId
+        }
+        return getNewId({ id: favorite.id, type: favorite.vocabularyItemType, apiKey: favorite.apiKey })
+      })
       .filter(it => it !== null)
     await AsyncStorage.setItem('favorites-2', JSON.stringify(newFavorites))
   }

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -166,10 +166,13 @@ export const migrate2To3 = async (): Promise<void> => {
       }
     }>
 
-    const updateUserVocabularyItem = (oldItem: OldUserVocabularyItem): NewUserVocabularyItem => ({
-      ...oldItem,
-      id: { index: oldItem.id, type: 'user-created' },
-    })
+    const updateUserVocabularyItem = (oldItem: OldUserVocabularyItem): NewUserVocabularyItem => {
+      if (typeof oldItem.id !== 'number') {
+        // Item is already in the new format (was migrated in a previous app launch)
+        return oldItem as unknown as NewUserVocabularyItem
+      }
+      return { ...oldItem, id: { index: oldItem.id, type: 'user-created' } }
+    }
 
     const oldUserVocabulary = await getStorageItemOr<OldUserVocabularyItem[]>('userVocabulary', [])
     const newUserVocabulary: NewUserVocabularyItem[] = oldUserVocabulary.map(updateUserVocabularyItem)


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The situation is described here:
https://chat.tuerantuer.org/digitalfabrik/pl/fft3ow8e5pr57kezbsb1syonay

It looks like we might be having a problem with our migrations: On a fresh installation, the storage version is never written to the AsyncStorage (only if `lastVersion !== STORAGE_VERSION`, which is not the case on a fresh installation, because we set `lastVersion` to be `STORAGE_VERSION` on a fresh installation). When the app then opens a second time, we try to migrate again, since there is no version in the AsyncStorage. This then breaks when trying to migrate the shape of the `WordNodeCard` because the old shape is already gone.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Always write the version to the AsyncStorage
- Update `migrate4To5` to also work if that migration has already been applied

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- We hopefully don't have white screens for our users anymore

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
I haven't been able to reproduce this issue at all, so this is a pretty theoretical exercise to me.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

It's a hotfix

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
