### PR TITLE
1421: Fix the color of the status bar

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -43,6 +43,12 @@ jest.mock('@react-navigation/elements', () => ({
   useHeaderHeight: jest.fn().mockImplementation(() => 200),
 }))
 
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useIsFocused: () => true,
+  useFocusEffect: jest.fn(),
+}))
+
 beforeEach(() => {
   jest.clearAllMocks()
   mockAsyncStorage.clear()

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native'
 import React, { ReactElement, ReactNode } from 'react'
 import { Platform, StatusBar } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -36,6 +37,7 @@ const RouteWrapper = ({
   shouldSetTopInset = false,
 }: RouteWrapperProps): ReactElement => {
   const insets = useSafeAreaInsets()
+  const isFocused = useIsFocused()
   return (
     <>
       <Container
@@ -44,10 +46,12 @@ const RouteWrapper = ({
         bottomInset={shouldSetBottomInset ? insets.bottom : undefined}
         topInset={shouldSetTopInset ? insets.top : undefined}
       >
-        <StatusBar
-          backgroundColor={backgroundColor}
-          barStyle={lightStatusBarContent ? 'light-content' : 'dark-content'}
-        />
+        {isFocused && (
+          <StatusBar
+            backgroundColor={backgroundColor}
+            barStyle={lightStatusBarContent ? 'light-content' : 'dark-content'}
+          />
+        )}
         {children}
       </Container>
       {/* For iOS a separate container is needed to overwrite the color of the bottom notch */}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
When there are multiple status bars mounted, react native always lets the most recently mounted 'win'. The behavior we want, however, is that only the currently active status bar is used.


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Only render the status bar if the current screen has focus, to prevent multiple status bars from "fighting" with each other

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that the color of the status bar now changes correctly when going back to the home screen

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1421

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
