### PR TITLE
1423: Remove top padding from the tab bar

### DIFF
--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -78,7 +78,6 @@ const BottomTabNavigator = (): ReactElement | null => {
           tabBarStyle: {
             backgroundColor: theme.colors.primary,
           },
-          tabBarItemStyle: { paddingTop: theme.spacingsPlain.xs },
           tabBarLabelStyle: { fontSize: TAB_LABEL_FONT_SIZE, paddingLeft: isTablet() ? theme.spacingsPlain.xs : 0 },
         }}
       >


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
On some android configurations it caused the buttons to be cut off.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the padding

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

On all devices the padding is now reduced

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test with an android device that is configured for 3-button navigation in the system settings

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1423 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
