### PR TITLE
Don't throw when running browserstack on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
             failure_mentions:
                 default: '@david.venhoff @leandra.hahn @johannes.stock'
                 type: string
-            only_for_branch:
+            on_failure_only_for_branch:
                 default: main
                 type: string
             success_mentions:
@@ -51,10 +51,12 @@ commands:
         steps:
             - run:
                 command: |
-                    if [ -n "<< parameters.failure_mentions >>" ]; then
-                        echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:\n<< parameters.failure_mentions >>"' >> $BASH_ENV
-                    else
-                        echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:"' >> $BASH_ENV
+                    if [ "<< parameters.on_failure_only_for_branch >>" = "${CIRCLE_BRANCH}" ]; then
+                        if [ -n "<< parameters.failure_mentions >>" ]; then
+                            echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:\n<< parameters.failure_mentions >>"' >> $BASH_ENV
+                        else
+                            echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:"' >> $BASH_ENV
+                        fi
                     fi
                 name: Mattermost - Prepare failure message
                 when: on_fail
@@ -74,11 +76,6 @@ commands:
                     #!/bin/bash
 
                     Send_notification() {
-                        if [ "<< parameters.only_for_branch >>" != "${CIRCLE_BRANCH}" ]; then
-                            echo "Not on << parameters.only_for_branch >> branch. Skipping."
-                            exit 0
-                        fi
-
                         if [ -z "${MM_MESSAGE}" ]; then
                             echo "No message set. Skipping."
                             exit 0
@@ -461,18 +458,30 @@ jobs:
                 command: mv ~/attached_workspace/${CIRCLE_BRANCH////-}.ipa ~/attached_workspace/app-release.ipa
                 name: Undo rename ipa
             - run:
-                command: "printf \"## App uploaded to Browserstack\\n\" >> message \nprintf \"This pull request can now be tested online:\\n\" >> message\nprintf -- \"- [Android](%s)\\n\" \"$(cat android/fastlane/browserstack_live_url)\" >> message\nprintf -- \"- [iOS](%s)\\n\" \"$(cat ios/fastlane/browserstack_live_url)\" >> message\n"
+                command: |
+                    printf "## App uploaded to Browserstack\n" >> message
+                    if [ -z "${PR_NUMBER}" ]; then
+                        printf "The %s branch can now be tested online:\n" "${CIRCLE_BRANCH}" >> message
+                    else
+                        printf "This pull request can now be tested online:\n" >> message
+                    fi
+                    printf -- "- [Android](%s)\n" "$(cat android/fastlane/browserstack_live_url)" >> message
+                    printf -- "- [iOS](%s)\n" "$(cat ios/fastlane/browserstack_live_url)" >> message
                 name: Build message
             - run:
                 command: |
+                    # ensure browserstack_message exists so the notify step's cat never errors
+                    touch ../browserstack_message
                     if [ -z "${PR_NUMBER}" ]; then
-                      echo "No PR number set, not creating a comment"
+                      # populate browserstack_message so that the notify will post the message in mattermost
+                      mv ../message ../browserstack_message
                     else
                       yarn app-toolbelt v0 notify github-pr ${PR_NUMBER} "$(cat ../message)" --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
                     fi
                 name: Post pull request comment with a link to the browserstack live apps
                 working_directory: tools
-            - notify
+            - notify:
+                success_message: $(cat browserstack_message)
     deliver_ios:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
@@ -585,7 +594,6 @@ jobs:
                 working_directory: tools
             - notify:
                 channel: releases
-                only_for_branch: ${CIRCLE_BRANCH}
                 success_message: Lunes - ${PROMOTION_MESSAGE}
     promote_android:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,12 @@ jobs:
                 command: "printf \"## App uploaded to Browserstack\\n\" >> message \nprintf \"This pull request can now be tested online:\\n\" >> message\nprintf -- \"- [Android](%s)\\n\" \"$(cat android/fastlane/browserstack_live_url)\" >> message\nprintf -- \"- [iOS](%s)\\n\" \"$(cat ios/fastlane/browserstack_live_url)\" >> message\n"
                 name: Build message
             - run:
-                command: yarn app-toolbelt v0 notify github-pr ${PR_NUMBER} "$(cat ../message)" --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+                command: |
+                    if [ -z "${PR_NUMBER}" ]; then
+                      echo "No PR number set, not creating a comment"
+                    else
+                      yarn app-toolbelt v0 notify github-pr ${PR_NUMBER} "$(cat ../message)" --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+                    fi
                 name: Post pull request comment with a link to the browserstack live apps
                 working_directory: tools
             - notify

--- a/.circleci/src/commands/notify.yml
+++ b/.circleci/src/commands/notify.yml
@@ -9,7 +9,7 @@ parameters:
   success_mentions:
     default: ''
     type: string
-  only_for_branch:
+  on_failure_only_for_branch:
     default: main
     type: string
   channel:
@@ -18,10 +18,12 @@ parameters:
 steps:
   - run:
       command: |
-        if [ -n "<< parameters.failure_mentions >>" ]; then
-            echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:\n<< parameters.failure_mentions >>"' >> $BASH_ENV
-        else
-            echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:"' >> $BASH_ENV
+        if [ "<< parameters.on_failure_only_for_branch >>" = "${CIRCLE_BRANCH}" ]; then
+            if [ -n "<< parameters.failure_mentions >>" ]; then
+                echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:\n<< parameters.failure_mentions >>"' >> $BASH_ENV
+            else
+                echo 'export MM_MESSAGE=":fire: The [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}) job has failed on the main branch! :fire:"' >> $BASH_ENV
+            fi
         fi
       name: Mattermost - Prepare failure message
       when: on_fail
@@ -41,11 +43,6 @@ steps:
         #!/bin/bash
 
         Send_notification() {
-            if [ "<< parameters.only_for_branch >>" != "${CIRCLE_BRANCH}" ]; then
-                echo "Not on << parameters.only_for_branch >> branch. Skipping."
-                exit 0
-            fi
-
             if [ -z "${MM_MESSAGE}" ]; then
                 echo "No message set. Skipping."
                 exit 0

--- a/.circleci/src/jobs/deliver_browser_stack.yml
+++ b/.circleci/src/jobs/deliver_browser_stack.yml
@@ -44,6 +44,11 @@ steps:
         printf -- "- [iOS](%s)\n" "$(cat ios/fastlane/browserstack_live_url)" >> message
   - run:
       name: Post pull request comment with a link to the browserstack live apps
-      command: yarn app-toolbelt v0 notify github-pr ${PR_NUMBER} "$(cat ../message)" --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+      command: |
+        if [ -z "${PR_NUMBER}" ]; then
+          echo "No PR number set, not creating a comment"
+        else
+          yarn app-toolbelt v0 notify github-pr ${PR_NUMBER} "$(cat ../message)" --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+        fi
       working_directory: tools
   - notify

--- a/.circleci/src/jobs/deliver_browser_stack.yml
+++ b/.circleci/src/jobs/deliver_browser_stack.yml
@@ -38,17 +38,25 @@ steps:
   - run:
       name: Build message
       command: |
-        printf "## App uploaded to Browserstack\n" >> message 
-        printf "This pull request can now be tested online:\n" >> message
+        printf "## App uploaded to Browserstack\n" >> message
+        if [ -z "${PR_NUMBER}" ]; then
+            printf "The %s branch can now be tested online:\n" "${CIRCLE_BRANCH}" >> message
+        else
+            printf "This pull request can now be tested online:\n" >> message
+        fi
         printf -- "- [Android](%s)\n" "$(cat android/fastlane/browserstack_live_url)" >> message
         printf -- "- [iOS](%s)\n" "$(cat ios/fastlane/browserstack_live_url)" >> message
   - run:
       name: Post pull request comment with a link to the browserstack live apps
       command: |
+        # ensure browserstack_message exists so the notify step's cat never errors
+        touch ../browserstack_message
         if [ -z "${PR_NUMBER}" ]; then
-          echo "No PR number set, not creating a comment"
+          # populate browserstack_message so that the notify will post the message in mattermost
+          mv ../message ../browserstack_message
         else
           yarn app-toolbelt v0 notify github-pr ${PR_NUMBER} "$(cat ../message)" --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
         fi
       working_directory: tools
-  - notify
+  - notify:
+      success_message: '$(cat browserstack_message)'

--- a/.circleci/src/jobs/notify_promotion.yml
+++ b/.circleci/src/jobs/notify_promotion.yml
@@ -16,4 +16,3 @@ steps:
   - notify:
       success_message: 'Lunes - ${PROMOTION_MESSAGE}'
       channel: releases
-      only_for_branch: ${CIRCLE_BRANCH}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This pr fixes the CI failure that happens when creating a browserstack build on main

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Don't try to post a message on a non-existing pull request
- Instead, post the message to mattermost

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
We'll see if this works in the next browserstack run

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1410 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
