### PR TITLE
1403: Don't limit screen orientation on android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
         android:exported="true"

--- a/src/components/AnalyticsConsentModal.tsx
+++ b/src/components/AnalyticsConsentModal.tsx
@@ -56,6 +56,7 @@ const AnalyticsConsentModal = ({ visible, onAllow, onDecline }: AnalyticsConsent
       transparent
       animationType='fade'
       onRequestClose={onDecline}
+      supportedOrientations={['landscape', 'portrait']}
     >
       <Overlay>
         <ModalContainer accessibilityViewIsModal>

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -78,7 +78,14 @@ const BottomSheet = ({ visible, ...props }: BottomSheetProps): ReactElement => {
   })
 
   return (
-    <Modal visible={shouldBeVisible} transparent animationType='none' statusBarTranslucent navigationBarTranslucent>
+    <Modal
+      visible={shouldBeVisible}
+      transparent
+      animationType='none'
+      statusBarTranslucent
+      navigationBarTranslucent
+      supportedOrientations={['landscape', 'portrait']}
+    >
       <ModalContainer style={{ backgroundColor: trimColor }}>
         <ModalBody
           backgroundColor={backgroundColor ?? theme.colors.backgroundHigh}

--- a/src/components/ModalSkeleton.tsx
+++ b/src/components/ModalSkeleton.tsx
@@ -58,6 +58,7 @@ const ModalSkeleton = ({ visible, onClose, testID, children }: ModalSkeletonProp
       animationType='fade'
       onRequestClose={onClose}
       accessibilityViewIsModal
+      supportedOrientations={['landscape', 'portrait']}
     >
       <StyledPressable onPress={handleBackdropPress} accessible={Platform.OS !== 'ios'}>
         <Overlay>

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -21,11 +21,15 @@ const Container = styled.View<{
   shouldTakeSpace: boolean
   bottomInset?: number
   topInset?: number
+  leftInset?: number
+  rightInset?: number
 }>`
   background-color: ${props => props.backgroundColor};
   flex: ${props => (props.shouldTakeSpace ? '1' : '0')};
   ${props => (props.topInset ? `padding-top: ${props.topInset}px` : undefined)};
   ${props => (props.bottomInset ? `padding-bottom: ${props.bottomInset}px` : undefined)};
+  ${props => (props.leftInset ? `padding-left: ${props.leftInset}px` : undefined)};
+  ${props => (props.rightInset ? `padding-right: ${props.rightInset}px` : undefined)};
 `
 
 const RouteWrapper = ({
@@ -45,6 +49,8 @@ const RouteWrapper = ({
         shouldTakeSpace
         bottomInset={shouldSetBottomInset ? insets.bottom : undefined}
         topInset={shouldSetTopInset ? insets.top : undefined}
+        leftInset={insets.left}
+        rightInset={insets.right}
       >
         {isFocused && (
           <StatusBar

--- a/src/constants/theme/sizes.ts
+++ b/src/constants/theme/sizes.ts
@@ -1,6 +1,7 @@
 const SIZES = {
   smallImage: '128px',
   defaultIcon: 28,
+  maximumImage: '512px',
 }
 
 export default SIZES

--- a/src/routes/exercise-finished/components/ExerciseFinishedBase.tsx
+++ b/src/routes/exercise-finished/components/ExerciseFinishedBase.tsx
@@ -11,9 +11,13 @@ import { HeadingBackground } from '../../../components/text/Heading'
 import { Color } from '../../../constants/theme/colors'
 import { getLabels, wordsDescription } from '../../../services/helpers'
 
+const ScrollContainer = styled.ScrollView`
+  flex: 1;
+`
+
 const Root = styled.View`
   background-color: ${prop => prop.theme.colors.background};
-  height: 100%;
+  flex: 1;
   align-items: center;
 `
 
@@ -61,30 +65,32 @@ const ExerciseFinishedBase = ({
 }: ExerciseFinishedBaseProps): ReactElement => {
   const theme = useTheme()
   return (
-    <Root>
-      <RoundedBackground color={theme.colors.primary}>
-        <AlignRight>
-          <IconButton onPress={onBack}>
-            <CloseIconWhite width={theme.sizes.defaultIcon} height={theme.sizes.defaultIcon} />
-          </IconButton>
-        </AlignRight>
-        <FeedbackIcon width={40} height={40} />
-        <MessageContainer>
-          <Message>{message}</Message>
-          <Results color={feedbackColor}>
-            {results.correct} {getLabels().results.of} {wordsDescription(results.total)} {getLabels().results.correct}
-          </Results>
-          <Progress.Bar
-            color={feedbackColor}
-            progress={results.correct / results.total}
-            unfilledColor={theme.colors.background}
-            borderWidth={0}
-          />
-        </MessageContainer>
-      </RoundedBackground>
+    <ScrollContainer contentContainerStyle={{ flexGrow: 1 }}>
+      <Root>
+        <RoundedBackground color={theme.colors.primary}>
+          <AlignRight>
+            <IconButton onPress={onBack}>
+              <CloseIconWhite width={theme.sizes.defaultIcon} height={theme.sizes.defaultIcon} />
+            </IconButton>
+          </AlignRight>
+          <FeedbackIcon width={40} height={40} />
+          <MessageContainer>
+            <Message>{message}</Message>
+            <Results color={feedbackColor}>
+              {results.correct} {getLabels().results.of} {wordsDescription(results.total)} {getLabels().results.correct}
+            </Results>
+            <Progress.Bar
+              color={feedbackColor}
+              progress={results.correct / results.total}
+              unfilledColor={theme.colors.background}
+              borderWidth={0}
+            />
+          </MessageContainer>
+        </RoundedBackground>
 
-      {children}
-    </Root>
+        {children}
+      </Root>
+    </ScrollContainer>
   )
 }
 

--- a/src/routes/settings/SettingsScreen.tsx
+++ b/src/routes/settings/SettingsScreen.tsx
@@ -17,6 +17,8 @@ import { getLabels } from '../../services/helpers'
 import DebugModal from './components/DebugModal'
 import VersionPressable from './components/VersionPressable'
 
+const Root = styled.ScrollView``
+
 const SettingsHeading = styled(Heading)`
   padding: ${props => props.theme.spacings.xl};
   text-align: center;
@@ -116,38 +118,44 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): ReactElement => {
         confirmationAction={closeDeletionModal}
         showCancelButton={false}
       />
-      <SettingsHeading>{settings}</SettingsHeading>
-      <SettingsOutline>
-        <ItemContainer>
-          <ItemTextContainer>
-            <Content>{analyticsConsentLabel}</Content>
-            <ContentTextLight>{analyticsConsentExplanation}</ContentTextLight>
-          </ItemTextContainer>
-          <Switch
-            testID='analytics-consent-switch'
-            value={isAnalyticsConsentGiven}
-            onValueChange={onAnalyticsConsentToggle}
-          />
-        </ItemContainer>
-        {installationId !== null && (
-          <GdprControls>
-            <PressableOpacity onPress={() => navigation.navigate('GdprExport')}>
-              <ContentText>{requestAnalyticsData}</ContentText>
-            </PressableOpacity>
-            <PressableOpacity onPress={() => setIsDeleteConfirmationVisible(true)}>
-              <DeleteText>{deleteAnalyticsDataLabel}</DeleteText>
-            </PressableOpacity>
-          </GdprControls>
-        )}
-      </SettingsOutline>
-      {isDevModeEnabled && (
+      <Root>
+        <SettingsHeading>{settings}</SettingsHeading>
         <SettingsOutline>
           <ItemContainer>
-            <Button onPress={() => setIsModalVisible(true)} label={devSettings} buttonTheme={BUTTONS_THEME.contained} />
+            <ItemTextContainer>
+              <Content>{analyticsConsentLabel}</Content>
+              <ContentTextLight>{analyticsConsentExplanation}</ContentTextLight>
+            </ItemTextContainer>
+            <Switch
+              testID='analytics-consent-switch'
+              value={isAnalyticsConsentGiven}
+              onValueChange={onAnalyticsConsentToggle}
+            />
           </ItemContainer>
+          {installationId !== null && (
+            <GdprControls>
+              <PressableOpacity onPress={() => navigation.navigate('GdprExport')}>
+                <ContentText>{requestAnalyticsData}</ContentText>
+              </PressableOpacity>
+              <PressableOpacity onPress={() => setIsDeleteConfirmationVisible(true)}>
+                <DeleteText>{deleteAnalyticsDataLabel}</DeleteText>
+              </PressableOpacity>
+            </GdprControls>
+          )}
         </SettingsOutline>
-      )}
-      <VersionPressable onClickThresholdReached={() => setIsModalVisible(true)} />
+        {isDevModeEnabled && (
+          <SettingsOutline>
+            <ItemContainer>
+              <Button
+                onPress={() => setIsModalVisible(true)}
+                label={devSettings}
+                buttonTheme={BUTTONS_THEME.contained}
+              />
+            </ItemContainer>
+          </SettingsOutline>
+        )}
+        <VersionPressable onClickThresholdReached={() => setIsModalVisible(true)} />
+      </Root>
     </RouteWrapper>
   )
 }

--- a/src/routes/settings/components/VersionPressable.tsx
+++ b/src/routes/settings/components/VersionPressable.tsx
@@ -6,8 +6,6 @@ import { ContentSecondary } from '../../../components/text/Content'
 import { getLabels } from '../../../services/helpers'
 
 const Version = styled.Pressable`
-  position: absolute;
-  bottom: 0;
   padding: ${props => props.theme.spacings.xl} ${props => props.theme.spacings.md};
 `
 

--- a/src/routes/training/SpeechTrainingScreen.tsx
+++ b/src/routes/training/SpeechTrainingScreen.tsx
@@ -56,6 +56,7 @@ const SPEECH_PERMISSIONS =
 const WordImageContainer = styled.View`
   padding: 0 ${props => props.theme.spacings.xxl};
   width: 100%;
+  max-width: ${props => props.theme.sizes.maximumImage};
 `
 
 const WordImage = styled.Image`

--- a/src/routes/training/TrainingExerciseSelectionScreen.tsx
+++ b/src/routes/training/TrainingExerciseSelectionScreen.tsx
@@ -46,7 +46,7 @@ export const TRAINING_EXERCISES: Record<TrainingType, TrainingExercise> = {
   },
 }
 
-const Root = styled.View`
+const Root = styled.ScrollView`
   padding: 0 ${props => props.theme.spacings.sm};
 `
 
@@ -146,6 +146,7 @@ const TrainingExerciseSelectionScreen = ({ route, navigation }: TrainingExercise
             data={Object.values(TRAINING_EXERCISES)}
             renderItem={renderListItem}
             showsVerticalScrollIndicator={false}
+            scrollEnabled={false}
           />
         </Root>
       </ServerResponseHandler>

--- a/src/routes/training/components/ImageGrid.tsx
+++ b/src/routes/training/components/ImageGrid.tsx
@@ -23,8 +23,6 @@ type ImageGridProps = {
   onPress: (key: VocabularyItemId) => void
 }
 
-const NUM_COLUMNS = 2
-
 const Grid = styled(View)`
   flex-direction: row;
   flex-wrap: wrap;
@@ -58,14 +56,19 @@ const StyledImage = styled.Image<{ width: number; padding: number; state: ImageG
 // Looks like there is no built-in way to create a responsive grid in React native, so let's do some manual layout...
 const ImageGrid = ({ items, onPress }: ImageGridProps): ReactElement => {
   const [availableWidth, setAvailableWidth] = useState(0)
+  const [isLandscape, setIsLandscape] = useState(false)
+  // If the screen is wide, we should fit all images into a single row instead of two rows.
+  // Otherwise, the images appear way too large
+  const numColumns = isLandscape ? 4 : 2
   const paddingPx = theme.spacingsPlain.xs
   // let's be a bit defensive here so that there are no unwanted overflows in the flow layout
-  const imageWidth = Math.floor((availableWidth - 2 * NUM_COLUMNS * paddingPx) / NUM_COLUMNS - 1)
+  const imageWidth = Math.floor((availableWidth - 2 * numColumns * paddingPx) / numColumns - 1)
 
   const onGridLayout = (event: LayoutChangeEvent): void => {
     if (availableWidth !== event.nativeEvent.layout.width) {
       setAvailableWidth(event.nativeEvent.layout.width)
     }
+    setIsLandscape(event.nativeEvent.layout.width > event.nativeEvent.layout.height)
   }
 
   return (

--- a/src/routes/training/components/ImageGrid.tsx
+++ b/src/routes/training/components/ImageGrid.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react'
-import { LayoutChangeEvent, View } from 'react-native'
+import { LayoutChangeEvent, useWindowDimensions, View } from 'react-native'
 import styled, { css } from 'styled-components/native'
 
 import PressableOpacity from '../../../components/PressableOpacity'
@@ -56,7 +56,8 @@ const StyledImage = styled.Image<{ width: number; padding: number; state: ImageG
 // Looks like there is no built-in way to create a responsive grid in React native, so let's do some manual layout...
 const ImageGrid = ({ items, onPress }: ImageGridProps): ReactElement => {
   const [availableWidth, setAvailableWidth] = useState(0)
-  const [isLandscape, setIsLandscape] = useState(false)
+  const windowDimensions = useWindowDimensions()
+  const isLandscape = windowDimensions.width > windowDimensions.height
   // If the screen is wide, we should fit all images into a single row instead of two rows.
   // Otherwise, the images appear way too large
   const numColumns = isLandscape ? 4 : 2
@@ -68,7 +69,6 @@ const ImageGrid = ({ items, onPress }: ImageGridProps): ReactElement => {
     if (availableWidth !== event.nativeEvent.layout.width) {
       setAvailableWidth(event.nativeEvent.layout.width)
     }
-    setIsLandscape(event.nativeEvent.layout.width > event.nativeEvent.layout.height)
   }
 
   return (


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Removes the limitation that the app may not be used in landscape mode and slightly adapts the UI to make the app also usable in the landscape mode.
It does not look great, especially on smartphones, but it looks okay in landscape mode. I think that is okay, since the app is mostly intended to be used on smartphones.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Allow non-portrait usage in the android manifest
- Respect left and right insets in the route wrapper. This should prevent UI being behind androids navigation bar
- Make all screens scrollable that weren't before
- Adjust the layouts of the image training and speech training modes to reduce the image size in landscape mode

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- While this is mostly a fix for android compatibility, it should also improve ios landscape mode

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test on a tablet and maybe a smartphone in landscape mode, the app should be usable and not look too bad

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1403 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
