### PR TITLE
1467: Fix job selection when keybard is open

### DIFF
--- a/src/routes/job-selection/JobSelectionScreen.tsx
+++ b/src/routes/job-selection/JobSelectionScreen.tsx
@@ -78,7 +78,7 @@ const JobSelectionScreen = ({ navigation, route }: JobSelectionScreenProps): Rea
       lightStatusBarContent={initialSelection}
       shouldSetBottomInset
     >
-      <ScrollView contentContainerStyle={{ paddingBottom: 120 }}>
+      <ScrollView contentContainerStyle={{ paddingBottom: 120 }} keyboardShouldPersistTaps='handled'>
         {initialSelection && <Header />}
 
         <TextContainer>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
When searching in the job selection and then tapping on a job, this PR closes the keyboard and selects the job at once.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go into the job selection (by pressing the plus in the home screen), type something into the search field, tap on a job, see that it is selected on the first tap, not just on the second one.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1467 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
