### PR TITLE
Fix inconsistent result screen for wordChoiceExercise

### DIFF
--- a/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
+++ b/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
@@ -39,7 +39,7 @@ type ExerciseFinishedScreenProps = {
 const ExerciseFinishedScreen = ({ navigation, route }: ExerciseFinishedScreenProps): ReactElement => {
   const { exercise, results, unitTitle } = route.params
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
-  const correctResults = results.filter(doc => doc.numberOfTries === 1)
+  const correctOnFirstAttempt = results.filter(doc => doc.numberOfTries === 1)
   const score = calculateScore(results)
 
   const { exercise: notNeededForNavigation1, results: notNeededForNavigation2, ...navigationParams } = route.params
@@ -117,7 +117,7 @@ const ExerciseFinishedScreen = ({ navigation, route }: ExerciseFinishedScreenPro
         </Modal>
       )}
       <ExerciseFinishedBase
-        results={{ correct: correctResults.length, total: results.length }}
+        results={{ correct: correctOnFirstAttempt.length, total: results.length }}
         feedbackColor={resultColor}
         FeedbackIcon={ResultIcon}
         message={message}

--- a/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
+++ b/src/routes/exercise-finished/ExerciseFinishedScreen.tsx
@@ -39,7 +39,7 @@ type ExerciseFinishedScreenProps = {
 const ExerciseFinishedScreen = ({ navigation, route }: ExerciseFinishedScreenProps): ReactElement => {
   const { exercise, results, unitTitle } = route.params
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
-  const correctResults = results.filter(doc => doc.result === 'correct')
+  const correctResults = results.filter(doc => doc.numberOfTries === 1)
   const score = calculateScore(results)
 
   const { exercise: notNeededForNavigation1, results: notNeededForNavigation2, ...navigationParams } = route.params

--- a/src/routes/exercise-finished/__tests__/ExerciseFinishedScreen.spec.tsx
+++ b/src/routes/exercise-finished/__tests__/ExerciseFinishedScreen.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { StandardExerciseKey, EXERCISES, StandardExerciseKeys } from '../../../constants/data'
 import { StandardUnitId } from '../../../models/Unit'
 import { RoutesParams } from '../../../navigation/NavigationTypes'
-import { getLabels } from '../../../services/helpers'
+import { getLabels, wordsDescription } from '../../../services/helpers'
 import VocabularyItemBuilder from '../../../testing/VocabularyItemBuilder'
 import createNavigationMock from '../../../testing/createNavigationPropMock'
 import render from '../../../testing/render'
@@ -33,7 +33,7 @@ describe('ExerciseFinishedScreen', () => {
         results: vocabularyItems.map((vocabularyItem, index) => ({
           vocabularyItem,
           result: !allCorrect && index < numberOfDifficultWords ? 'incorrect' : 'correct',
-          numberOfTries: !allCorrect && index < numberOfDifficultWords ? 3 : 1,
+          numberOfTries: index < numberOfDifficultWords ? 3 : 1,
         })),
       },
     }
@@ -88,5 +88,16 @@ describe('ExerciseFinishedScreen', () => {
     const button = getByText(getLabels().results.action.finished)
     fireEvent.press(button)
     expect(navigation.pop).toHaveBeenCalled()
+  })
+
+  it('should count words as incorrect even if they have only initially been answered incorrectly', () => {
+    const route = getRoute(StandardExerciseKeys.wordChoiceExercise, true, false, 4)
+    const { getByText } = render(<ExerciseFinishedScreen route={route} navigation={navigation} />)
+
+    const correctWords = 0
+    const totalWords = 4
+    const summaryMessage = `${correctWords} ${getLabels().results.of} ${wordsDescription(totalWords)} ${getLabels().results.correct}`
+    expect(getByText(summaryMessage)).toBeVisible()
+    expect(getByText(getLabels().results.action.repeat)).toBeVisible()
   })
 })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Instead of counting the words that have been answered correctly after any number of attempts, only count words that have been answered correctly initially.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Adapt the way how we count correct words in the result screen

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to a word choice exercise, initially answer all words wrong and then correctly. 
Previously the screen would then show that all words are correct and now it should show that no words are correct.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1446 
Fixes: #992 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
