### PR TITLE
1493: respect reduced-motion setting

### DIFF
--- a/release-notes/unreleased/1493-reduced-motion.yml
+++ b/release-notes/unreleased/1493-reduced-motion.yml
@@ -1,0 +1,6 @@
+issue_key: 1493
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Wer im Betriebssystem Bewegungen reduziert hat, sieht Übergänge jetzt als sanftes Ein- und Ausblenden statt als Bewegung.

--- a/release-notes/unreleased/1493-reduced-motion.yml
+++ b/release-notes/unreleased/1493-reduced-motion.yml
@@ -3,4 +3,4 @@ show_in_stores: true
 platforms:
   - android
   - ios
-de: Wer im Betriebssystem Bewegungen reduziert hat, sieht Übergänge jetzt als sanftes Ein- und Ausblenden statt als Bewegung.
+de: Wer im Betriebssystem Bewegungen reduziert hat, sieht in der App keine gleitenden Übergänge mehr.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from 'styled-components/native'
 
 import theme from './constants/theme'
 import Navigator from './navigation/Navigator'
+import ReducedMotionServiceProvider from './services/ReducedMotionService'
 import StorageProvider from './services/Storage'
 import TtsServiceProvider from './services/TtsService'
 import VolumeServiceProvider from './services/VolumeService'
@@ -27,9 +28,11 @@ const App = (): ReactElement => {
           <StorageProvider>
             <VolumeServiceProvider>
               <TtsServiceProvider>
-                <NavigationContainer>
-                  <Navigator />
-                </NavigationContainer>
+                <ReducedMotionServiceProvider>
+                  <NavigationContainer>
+                    <Navigator />
+                  </NavigationContainer>
+                </ReducedMotionServiceProvider>
               </TtsServiceProvider>
             </VolumeServiceProvider>
           </StorageProvider>

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -4,6 +4,9 @@ import { initialWindowMetrics } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
 import { Color } from '../constants/theme/colors'
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
+
+const EASING = Easing.out(Easing.ease)
 
 const ModalContainer = styled(Animated.View)`
   display: flex;
@@ -48,6 +51,7 @@ const BottomSheet = ({ visible, ...props }: BottomSheetProps): ReactElement => {
   const bottomPadding = initialWindowMetrics?.insets.bottom ?? 0
 
   const { durationMs } = theme.animations
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const slideInAnimation = useRef(new Animated.Value(0)).current
   useEffect(() => {
     if (visible) {
@@ -55,14 +59,14 @@ const BottomSheet = ({ visible, ...props }: BottomSheetProps): ReactElement => {
       Animated.timing(slideInAnimation, {
         toValue: 1,
         duration: durationMs,
-        easing: Easing.out(Easing.ease),
+        easing: EASING,
         useNativeDriver: true,
       }).start()
     } else {
       Animated.timing(slideInAnimation, {
         toValue: 0,
         duration: durationMs,
-        easing: Easing.out(Easing.ease),
+        easing: EASING,
         useNativeDriver: true,
       }).start(() => setShouldBeVisible(false))
     }
@@ -76,6 +80,9 @@ const BottomSheet = ({ visible, ...props }: BottomSheetProps): ReactElement => {
     inputRange: [0, 1],
     outputRange: [height, 0],
   })
+  const bodyAnimation = isReducedMotionEnabled
+    ? { opacity: slideInAnimation }
+    : { transform: [{ translateY: offset }, { perspective: 1000 }] }
 
   return (
     <Modal
@@ -90,7 +97,7 @@ const BottomSheet = ({ visible, ...props }: BottomSheetProps): ReactElement => {
         <ModalBody
           backgroundColor={backgroundColor ?? theme.colors.backgroundHigh}
           bottomPadding={bottomPadding}
-          style={{ transform: [{ translateY: offset }, { perspective: 1000 }] }}
+          style={bodyAnimation}
         >
           {children}
         </ModalBody>

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -95,7 +95,6 @@ const BadgeLabel = styled.Text<{ pressed: boolean }>`
   margin-right: ${props => props.theme.spacings.xxs};
 `
 
-const PRESS_ANIMATION_DURATION = 300
 const PRESS_MAX_DRAG_Y = 5
 
 type ListItemProps = {
@@ -141,13 +140,13 @@ const ListItem = ({
         if (onPress) {
           onPress()
         }
-        setTimeout(() => updatePressed(false), PRESS_ANIMATION_DURATION)
+        setTimeout(() => updatePressed(false), theme.animations.durationMs)
       } else {
         updatePressed(false)
       }
       setPressInY(null)
     },
-    [pressInY, updatePressed, onPress],
+    [pressInY, updatePressed, onPress, theme.animations.durationMs],
   )
 
   const titleToRender =

--- a/src/components/__tests__/BottomSheet.spec.tsx
+++ b/src/components/__tests__/BottomSheet.spec.tsx
@@ -1,0 +1,38 @@
+import { waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { Text } from 'react-native'
+
+import useIsReducedMotionEnabled from '../../hooks/useIsReducedMotionEnabled'
+import render from '../../testing/render'
+import BottomSheet from '../BottomSheet'
+
+jest.mock('../../hooks/useIsReducedMotionEnabled')
+
+describe('BottomSheet', () => {
+  const content = 'Sheet content'
+
+  const renderSheet = (visible: boolean) =>
+    render(
+      <BottomSheet visible={visible}>
+        <Text>{content}</Text>
+      </BottomSheet>,
+    )
+
+  describe('with reduced motion', () => {
+    it('should show the content while visible and hide it again once closed', async () => {
+      jest.mocked(useIsReducedMotionEnabled).mockReturnValue(true)
+
+      const { queryByText, rerender } = renderSheet(true)
+      expect(queryByText(content)).toBeTruthy()
+
+      // The sheet stays mounted until the closing animation completed, so it only disappears afterwards
+      rerender(
+        <BottomSheet visible={false}>
+          <Text>{content}</Text>
+        </BottomSheet>,
+      )
+
+      await waitFor(() => expect(queryByText(content)).toBeNull())
+    })
+  })
+})

--- a/src/hooks/__tests__/useIsReducedMotionEnabled.spec.ts
+++ b/src/hooks/__tests__/useIsReducedMotionEnabled.spec.ts
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import { AccessibilityInfo, EmitterSubscription } from 'react-native'
+
+import useIsReducedMotionEnabled from '../useIsReducedMotionEnabled'
+
+type ReduceMotionHandler = (isReduceMotionEnabled: boolean) => void
+
+describe('useIsReducedMotionEnabled', () => {
+  const removeListener = jest.fn()
+  let notifyReduceMotionChanged: ReduceMotionHandler
+
+  const mockAccessibilityInfo = (isEnabledInitially: boolean): void => {
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(isEnabledInitially)
+    // The signature is cast because addEventListener is overloaded for every accessibility event
+    jest.spyOn(AccessibilityInfo, 'addEventListener').mockImplementation((_eventName, handler) => {
+      notifyReduceMotionChanged = handler as unknown as ReduceMotionHandler
+      return { remove: removeListener } as unknown as EmitterSubscription
+    })
+  }
+
+  describe('when the setting is disabled', () => {
+    it('should report that motion is not reduced', async () => {
+      mockAccessibilityInfo(false)
+
+      const { result } = renderHook(() => useIsReducedMotionEnabled())
+
+      await waitFor(() => expect(result.current).toBe(false))
+    })
+  })
+
+  describe('when the setting is enabled', () => {
+    it('should report that motion is reduced', async () => {
+      mockAccessibilityInfo(true)
+
+      const { result } = renderHook(() => useIsReducedMotionEnabled())
+
+      await waitFor(() => expect(result.current).toBe(true))
+    })
+  })
+
+  describe('when the setting is toggled while running', () => {
+    it('should report the new value without a restart', async () => {
+      mockAccessibilityInfo(false)
+
+      const { result } = renderHook(() => useIsReducedMotionEnabled())
+      await waitFor(() => expect(result.current).toBe(false))
+
+      act(() => notifyReduceMotionChanged(true))
+
+      expect(result.current).toBe(true)
+    })
+  })
+
+  it('should stop listening when unmounted', async () => {
+    mockAccessibilityInfo(false)
+
+    const { unmount } = renderHook(() => useIsReducedMotionEnabled())
+    await waitFor(() => expect(AccessibilityInfo.addEventListener).toHaveBeenCalled())
+
+    unmount()
+
+    expect(removeListener).toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useIsReducedMotionEnabled.ts
+++ b/src/hooks/useIsReducedMotionEnabled.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { AccessibilityInfo } from 'react-native'
+
+import { reportError } from '../services/sentry'
+
+const useIsReducedMotionEnabled = (): boolean => {
+  const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState<boolean>(false)
+
+  useEffect(() => {
+    const loadInitialValue = async (): Promise<void> =>
+      setIsReducedMotionEnabled(await AccessibilityInfo.isReduceMotionEnabled())
+    loadInitialValue().catch(reportError)
+
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setIsReducedMotionEnabled)
+    return subscription.remove
+  }, [])
+
+  return isReducedMotionEnabled
+}
+
+export default useIsReducedMotionEnabled

--- a/src/hooks/useIsReducedMotionEnabled.ts
+++ b/src/hooks/useIsReducedMotionEnabled.ts
@@ -1,21 +1,7 @@
-import { useEffect, useState } from 'react'
-import { AccessibilityInfo } from 'react-native'
+import { useContext } from 'react'
 
-import { reportError } from '../services/sentry'
+import { ReducedMotionServiceContext } from '../services/ReducedMotionService'
 
-const useIsReducedMotionEnabled = (): boolean => {
-  const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState<boolean>(false)
-
-  useEffect(() => {
-    const loadInitialValue = async (): Promise<void> =>
-      setIsReducedMotionEnabled(await AccessibilityInfo.isReduceMotionEnabled())
-    loadInitialValue().catch(reportError)
-
-    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setIsReducedMotionEnabled)
-    return subscription.remove
-  }, [])
-
-  return isReducedMotionEnabled
-}
+const useIsReducedMotionEnabled = (): boolean => useContext(ReducedMotionServiceContext)
 
 export default useIsReducedMotionEnabled

--- a/src/navigation/DictionaryStackNavigator.tsx
+++ b/src/navigation/DictionaryStackNavigator.tsx
@@ -1,20 +1,22 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import DictionaryScreen from '../routes/dictionary/DictionaryScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const DictionaryStackNavigator = (): ReactElement => {
   const options = screenOptions(useTabletHeaderHeight())
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={reducedMotionScreenOptions(isReducedMotionEnabled)}>
       <Stack.Screen
         name='Dictionary'
         component={DictionaryScreen}

--- a/src/navigation/DictionaryStackNavigator.tsx
+++ b/src/navigation/DictionaryStackNavigator.tsx
@@ -1,22 +1,20 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
-import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import DictionaryScreen from '../routes/dictionary/DictionaryScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { useStackScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const DictionaryStackNavigator = (): ReactElement => {
   const options = screenOptions(useTabletHeaderHeight())
-  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator screenOptions={reducedMotionScreenOptions(isReducedMotionEnabled)}>
+    <Stack.Navigator screenOptions={useStackScreenOptions()}>
       <Stack.Screen
         name='Dictionary'
         component={DictionaryScreen}

--- a/src/navigation/FavoritesStackNavigator.tsx
+++ b/src/navigation/FavoritesStackNavigator.tsx
@@ -1,20 +1,24 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import FavoritesScreen from '../routes/favorites/FavoritesScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const FavoritesStackNavigator = (): ReactElement => {
   const options = screenOptions(useTabletHeaderHeight())
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator screenOptions={{ headerStatusBarHeight: 0 }}>
+    <Stack.Navigator
+      screenOptions={{ headerStatusBarHeight: 0, ...reducedMotionScreenOptions(isReducedMotionEnabled) }}
+    >
       <Stack.Screen name='Favorites' component={FavoritesScreen} options={{ headerShown: false }} />
       <Stack.Screen
         name='VocabularyDetail'

--- a/src/navigation/FavoritesStackNavigator.tsx
+++ b/src/navigation/FavoritesStackNavigator.tsx
@@ -1,24 +1,20 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
-import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import FavoritesScreen from '../routes/favorites/FavoritesScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { useStackScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const FavoritesStackNavigator = (): ReactElement => {
   const options = screenOptions(useTabletHeaderHeight())
-  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator
-      screenOptions={{ headerStatusBarHeight: 0, ...reducedMotionScreenOptions(isReducedMotionEnabled) }}
-    >
+    <Stack.Navigator screenOptions={useStackScreenOptions({ headerStatusBarHeight: 0 })}>
       <Stack.Screen name='Favorites' component={FavoritesScreen} options={{ headerShown: false }} />
       <Stack.Screen
         name='VocabularyDetail'

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -2,6 +2,7 @@ import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 import { useTheme } from 'styled-components/native'
 
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import ImprintScreen from '../routes/ImprintScreen'
 import UnitSelectionScreen from '../routes/UnitSelectionScreen'
 import StandardExercisesScreen from '../routes/exercises/StandardExercisesScreen'
@@ -13,17 +14,23 @@ import SponsorsScreen from '../routes/sponsors/SponsorsScreen'
 import TrainingExerciseSelectionScreen from '../routes/training/TrainingExerciseSelectionScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const HomeStackNavigator = (): ReactElement | null => {
   const options = screenOptions(useTabletHeaderHeight())
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { manageJobs, overview, units, settings } = getLabels().general.header
   const theme = useTheme()
 
   return (
-    <Stack.Navigator screenOptions={{ cardStyle: { backgroundColor: theme.colors.background } }}>
+    <Stack.Navigator
+      screenOptions={{
+        cardStyle: { backgroundColor: theme.colors.background },
+        ...reducedMotionScreenOptions(isReducedMotionEnabled),
+      }}
+    >
       <Stack.Screen name='Home' component={HomeScreen} options={{ headerShown: false }} />
       <Stack.Screen
         name='UnitSelection'

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -2,7 +2,6 @@ import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 import { useTheme } from 'styled-components/native'
 
-import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import ImprintScreen from '../routes/ImprintScreen'
 import UnitSelectionScreen from '../routes/UnitSelectionScreen'
 import StandardExercisesScreen from '../routes/exercises/StandardExercisesScreen'
@@ -14,23 +13,17 @@ import SponsorsScreen from '../routes/sponsors/SponsorsScreen'
 import TrainingExerciseSelectionScreen from '../routes/training/TrainingExerciseSelectionScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { useStackScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const HomeStackNavigator = (): ReactElement | null => {
   const options = screenOptions(useTabletHeaderHeight())
-  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { manageJobs, overview, units, settings } = getLabels().general.header
   const theme = useTheme()
 
   return (
-    <Stack.Navigator
-      screenOptions={{
-        cardStyle: { backgroundColor: theme.colors.background },
-        ...reducedMotionScreenOptions(isReducedMotionEnabled),
-      }}
-    >
+    <Stack.Navigator screenOptions={useStackScreenOptions({ cardStyle: { backgroundColor: theme.colors.background } })}>
       <Stack.Screen name='Home' component={HomeScreen} options={{ headerShown: false }} />
       <Stack.Screen
         name='UnitSelection'

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -17,7 +17,7 @@ import VocabularyDetailExerciseScreen from '../routes/vocabulary-detail-exercise
 import { getLabels } from '../services/helpers'
 import BottomTabNavigator from './BottomTabNavigator'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { useStackScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
@@ -34,7 +34,7 @@ const HomeStackNavigator = (): ReactElement | null => {
   return (
     <Stack.Navigator
       initialRouteName={jobs === null ? 'JobSelection' : 'BottomTabNavigator'}
-      screenOptions={reducedMotionScreenOptions(isReducedMotionEnabled)}
+      screenOptions={useStackScreenOptions()}
     >
       <Stack.Screen name='BottomTabNavigator' component={BottomTabNavigator} options={{ headerShown: false }} />
       <Stack.Screen

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -1,9 +1,10 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import useStorage from '../hooks/useStorage'
 import useTrackSession from '../hooks/useTrackSession'
-import OverlayMenu, { OverlayTransition } from '../routes/OverlayMenuScreen'
+import OverlayMenu, { overlayTransition } from '../routes/OverlayMenuScreen'
 import VocabularyListScreen from '../routes/VocabularyListScreen'
 import WordChoiceExerciseScreen from '../routes/choice-exercises/WordChoiceExerciseScreen'
 import ExerciseFinishedScreen from '../routes/exercise-finished/ExerciseFinishedScreen'
@@ -16,7 +17,7 @@ import VocabularyDetailExerciseScreen from '../routes/vocabulary-detail-exercise
 import { getLabels } from '../services/helpers'
 import BottomTabNavigator from './BottomTabNavigator'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
@@ -26,11 +27,15 @@ const HomeStackNavigator = (): ReactElement | null => {
 
   const headerHeight = useTabletHeaderHeight()
   const options = screenOptions(headerHeight)
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
 
   const { manageJobs, overviewExercises, cancelExercise } = getLabels().general.header
 
   return (
-    <Stack.Navigator initialRouteName={jobs === null ? 'JobSelection' : 'BottomTabNavigator'}>
+    <Stack.Navigator
+      initialRouteName={jobs === null ? 'JobSelection' : 'BottomTabNavigator'}
+      screenOptions={reducedMotionScreenOptions(isReducedMotionEnabled)}
+    >
       <Stack.Screen name='BottomTabNavigator' component={BottomTabNavigator} options={{ headerShown: false }} />
       <Stack.Screen
         name='JobSelection'
@@ -41,7 +46,11 @@ const HomeStackNavigator = (): ReactElement | null => {
       <Stack.Screen
         name='OverlayMenu'
         component={OverlayMenu}
-        options={{ presentation: 'transparentModal', headerShown: false, ...OverlayTransition }}
+        options={{
+          presentation: 'transparentModal',
+          headerShown: false,
+          ...overlayTransition(isReducedMotionEnabled),
+        }}
       />
       <Stack.Screen
         name='VocabularyList'

--- a/src/navigation/RepetitionStackNavigator.tsx
+++ b/src/navigation/RepetitionStackNavigator.tsx
@@ -1,21 +1,23 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import RepetitionScreen from '../routes/repetition/RepetitionScreen'
 import RepetitionWordListScreen from '../routes/repetition/RepetitionWordListScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const RepetitionStackNavigator = (): ReactElement | null => {
   const options = screenOptions(useTabletHeaderHeight())
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={reducedMotionScreenOptions(isReducedMotionEnabled)}>
       <Stack.Screen
         name='Repetition'
         component={RepetitionScreen}

--- a/src/navigation/RepetitionStackNavigator.tsx
+++ b/src/navigation/RepetitionStackNavigator.tsx
@@ -1,23 +1,21 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 
-import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import VocabularyDetailScreen from '../routes/VocabularyDetailScreen'
 import RepetitionScreen from '../routes/repetition/RepetitionScreen'
 import RepetitionWordListScreen from '../routes/repetition/RepetitionWordListScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { useStackScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const RepetitionStackNavigator = (): ReactElement | null => {
   const options = screenOptions(useTabletHeaderHeight())
-  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const { back } = getLabels().general
 
   return (
-    <Stack.Navigator screenOptions={reducedMotionScreenOptions(isReducedMotionEnabled)}>
+    <Stack.Navigator screenOptions={useStackScreenOptions()}>
       <Stack.Screen
         name='Repetition'
         component={RepetitionScreen}

--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -2,7 +2,6 @@ import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 import { useTheme } from 'styled-components/native'
 
-import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import UserVocabularyOverviewScreen from '../routes/UserVocabularyOverviewScreen'
 import { EditableVocabularyDetailsScreen } from '../routes/VocabularyDetailScreen'
 import UserVocabularyProcessScreen from '../routes/process-user-vocabulary/UserVocabularyProcessScreen'
@@ -11,24 +10,22 @@ import UserVocabularyListScreen from '../routes/user-vocabulary-list/UserVocabul
 import UserVocabularyUnitSelectionScreen from '../routes/user-vocabulary-unit-selection/UserVocabularyUnitSelectionScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { useStackScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const UserVocabularyStackNavigator = (): ReactElement | null => {
   const headerHeight = useTabletHeaderHeight()
   const options = screenOptions(headerHeight)
-  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const back = getLabels().general.back
   const theme = useTheme()
 
   return (
     <Stack.Navigator
-      screenOptions={{
+      screenOptions={useStackScreenOptions({
         cardStyle: { backgroundColor: theme.colors.background },
         headerStatusBarHeight: 0,
-        ...reducedMotionScreenOptions(isReducedMotionEnabled),
-      }}
+      })}
     >
       <Stack.Screen
         name='UserVocabularyOverview'

--- a/src/navigation/UserVocabularyStackNavigator.tsx
+++ b/src/navigation/UserVocabularyStackNavigator.tsx
@@ -2,6 +2,7 @@ import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement } from 'react'
 import { useTheme } from 'styled-components/native'
 
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import UserVocabularyOverviewScreen from '../routes/UserVocabularyOverviewScreen'
 import { EditableVocabularyDetailsScreen } from '../routes/VocabularyDetailScreen'
 import UserVocabularyProcessScreen from '../routes/process-user-vocabulary/UserVocabularyProcessScreen'
@@ -10,19 +11,24 @@ import UserVocabularyListScreen from '../routes/user-vocabulary-list/UserVocabul
 import UserVocabularyUnitSelectionScreen from '../routes/user-vocabulary-unit-selection/UserVocabularyUnitSelectionScreen'
 import { getLabels } from '../services/helpers'
 import { RoutesParams } from './NavigationTypes'
-import screenOptions, { useTabletHeaderHeight } from './screenOptions'
+import screenOptions, { reducedMotionScreenOptions, useTabletHeaderHeight } from './screenOptions'
 
 const Stack = createStackNavigator<RoutesParams>()
 
 const UserVocabularyStackNavigator = (): ReactElement | null => {
   const headerHeight = useTabletHeaderHeight()
   const options = screenOptions(headerHeight)
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
   const back = getLabels().general.back
   const theme = useTheme()
 
   return (
     <Stack.Navigator
-      screenOptions={{ cardStyle: { backgroundColor: theme.colors.background }, headerStatusBarHeight: 0 }}
+      screenOptions={{
+        cardStyle: { backgroundColor: theme.colors.background },
+        headerStatusBarHeight: 0,
+        ...reducedMotionScreenOptions(isReducedMotionEnabled),
+      }}
     >
       <Stack.Screen
         name='UserVocabularyOverview'

--- a/src/navigation/VocabularyCollectionTabNavigator.tsx
+++ b/src/navigation/VocabularyCollectionTabNavigator.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import theme from '../constants/theme'
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import { getLabels } from '../services/helpers'
 import FavoritesStackNavigator from './FavoritesStackNavigator'
 import { RoutesParams } from './NavigationTypes'
@@ -12,6 +13,7 @@ const Tab = createMaterialTopTabNavigator<RoutesParams>()
 
 const VocabularyCollectionTabNavigator = (): ReactElement | null => {
   const insets = useSafeAreaInsets()
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
 
   return (
     <Tab.Navigator
@@ -19,6 +21,7 @@ const VocabularyCollectionTabNavigator = (): ReactElement | null => {
       screenOptions={{
         tabBarIndicatorStyle: { backgroundColor: theme.colors.primary, height: 4 },
         tabBarStyle: { paddingTop: insets.top },
+        animationEnabled: !isReducedMotionEnabled,
       }}
     >
       <Tab.Screen

--- a/src/navigation/screenOptions.tsx
+++ b/src/navigation/screenOptions.tsx
@@ -6,6 +6,7 @@ import { StyleSheet, useWindowDimensions } from 'react-native'
 import NavigationHeaderLeft from '../components/NavigationHeaderLeft'
 import { COLORS } from '../constants/theme/colors'
 import { SPACINGS_PLAIN } from '../constants/theme/spacings'
+import useIsReducedMotionEnabled from '../hooks/useIsReducedMotionEnabled'
 import { RoutesParams } from './NavigationTypes'
 
 const MOBILE_MAX_WIDTH = 550
@@ -39,8 +40,15 @@ const headerStyles = (headerHeight?: number) =>
     },
   })
 
-export const reducedMotionScreenOptions = (isReducedMotionEnabled: boolean): StackNavigationOptions =>
-  isReducedMotionEnabled ? { animation: 'none' } : {}
+export const useStackScreenOptions = (options?: StackNavigationOptions): StackNavigationOptions => {
+  const isReducedMotionEnabled = useIsReducedMotionEnabled()
+
+  if (!isReducedMotionEnabled) {
+    return options ?? {}
+  }
+
+  return { ...options, animation: 'none' }
+}
 
 const screenOptions =
   (headerHeight?: number) =>

--- a/src/navigation/screenOptions.tsx
+++ b/src/navigation/screenOptions.tsx
@@ -39,6 +39,9 @@ const headerStyles = (headerHeight?: number) =>
     },
   })
 
+export const reducedMotionScreenOptions = (isReducedMotionEnabled: boolean): StackNavigationOptions =>
+  isReducedMotionEnabled ? { animation: 'none' } : {}
+
 const screenOptions =
   (headerHeight?: number) =>
   (title: string, navigation: NavigationProp<RoutesParams>, isCloseButton = false): StackNavigationOptions => {

--- a/src/routes/OverlayMenuScreen.tsx
+++ b/src/routes/OverlayMenuScreen.tsx
@@ -42,13 +42,15 @@ const Icon = styled.Pressable`
   color: ${props => props.theme.colors.backgroundAccent};
 `
 
-export const OverlayTransition: StackNavigationOptions = {
+export const overlayTransition = (isReducedMotionEnabled: boolean): StackNavigationOptions => ({
   gestureEnabled: true,
   gestureDirection: 'horizontal',
-  cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
+  cardStyleInterpolator: isReducedMotionEnabled
+    ? CardStyleInterpolators.forFadeFromCenter
+    : CardStyleInterpolators.forHorizontalIOS,
   cardOverlayEnabled: true,
   cardOverlay: () => <OverlayContainer />,
-}
+})
 
 type OverlayProps = {
   navigation: StackNavigationProp<RoutesParams>

--- a/src/services/ReducedMotionService.tsx
+++ b/src/services/ReducedMotionService.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, ReactElement, useEffect, useState } from 'react'
+import { AccessibilityInfo } from 'react-native'
+
+import { reportError } from './sentry'
+
+export const ReducedMotionServiceContext = createContext<boolean>(false)
+
+export type ReducedMotionServiceProviderProps = {
+  children: ReactElement
+}
+
+const ReducedMotionServiceProvider = ({ children }: ReducedMotionServiceProviderProps): ReactElement => {
+  const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState<boolean>(false)
+
+  useEffect(() => {
+    const loadInitialValue = async (): Promise<void> =>
+      setIsReducedMotionEnabled(await AccessibilityInfo.isReduceMotionEnabled())
+    loadInitialValue().catch(reportError)
+
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setIsReducedMotionEnabled)
+    return subscription.remove
+  }, [])
+
+  return (
+    <ReducedMotionServiceContext.Provider value={isReducedMotionEnabled}>
+      {children}
+    </ReducedMotionServiceContext.Provider>
+  )
+}
+
+export default ReducedMotionServiceProvider

--- a/src/services/__tests__/ReducedMotionService.spec.tsx
+++ b/src/services/__tests__/ReducedMotionService.spec.tsx
@@ -1,11 +1,13 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native'
+import React, { ReactElement } from 'react'
 import { AccessibilityInfo, EmitterSubscription } from 'react-native'
 
-import useIsReducedMotionEnabled from '../useIsReducedMotionEnabled'
+import useIsReducedMotionEnabled from '../../hooks/useIsReducedMotionEnabled'
+import ReducedMotionServiceProvider from '../ReducedMotionService'
 
 type ReduceMotionHandler = (isReduceMotionEnabled: boolean) => void
 
-describe('useIsReducedMotionEnabled', () => {
+describe('ReducedMotionService', () => {
   const removeListener = jest.fn()
   let notifyReduceMotionChanged: ReduceMotionHandler
 
@@ -18,11 +20,17 @@ describe('useIsReducedMotionEnabled', () => {
     })
   }
 
+  const wrapper = ({ children }: { children: ReactElement }): ReactElement => (
+    <ReducedMotionServiceProvider>{children}</ReducedMotionServiceProvider>
+  )
+
+  const renderReducedMotionHook = () => renderHook(() => useIsReducedMotionEnabled(), { wrapper })
+
   describe('when the setting is disabled', () => {
     it('should report that motion is not reduced', async () => {
       mockAccessibilityInfo(false)
 
-      const { result } = renderHook(() => useIsReducedMotionEnabled())
+      const { result } = renderReducedMotionHook()
 
       await waitFor(() => expect(result.current).toBe(false))
     })
@@ -32,7 +40,7 @@ describe('useIsReducedMotionEnabled', () => {
     it('should report that motion is reduced', async () => {
       mockAccessibilityInfo(true)
 
-      const { result } = renderHook(() => useIsReducedMotionEnabled())
+      const { result } = renderReducedMotionHook()
 
       await waitFor(() => expect(result.current).toBe(true))
     })
@@ -42,7 +50,7 @@ describe('useIsReducedMotionEnabled', () => {
     it('should report the new value without a restart', async () => {
       mockAccessibilityInfo(false)
 
-      const { result } = renderHook(() => useIsReducedMotionEnabled())
+      const { result } = renderReducedMotionHook()
       await waitFor(() => expect(result.current).toBe(false))
 
       act(() => notifyReduceMotionChanged(true))
@@ -51,10 +59,21 @@ describe('useIsReducedMotionEnabled', () => {
     })
   })
 
+  describe('when several components read the setting', () => {
+    it('should subscribe to the accessibility info only once', async () => {
+      mockAccessibilityInfo(true)
+
+      const { result } = renderHook(() => [useIsReducedMotionEnabled(), useIsReducedMotionEnabled()], { wrapper })
+
+      await waitFor(() => expect(result.current).toEqual([true, true]))
+      expect(AccessibilityInfo.addEventListener).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('should stop listening when unmounted', async () => {
     mockAccessibilityInfo(false)
 
-    const { unmount } = renderHook(() => useIsReducedMotionEnabled())
+    const { unmount } = renderReducedMotionHook()
     await waitFor(() => expect(AccessibilityInfo.addEventListener).toHaveBeenCalled())
 
     unmount()


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
We really should have been respecting the prefers-reduced-motion setting for a long time. This PR fixes that situation.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add a hook to check if reduced motion is enabled
- Use that hook in the navigators (I disabled all animation there because fade looked weird)
- Use that hook in the bottom sheet, where I did use fade
- Removed a hard-coded 300ms animation in the ListItem. The default is now 250ms, I don't expect anybody to notice the difference.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Well, I guess someone might notice a 50ms difference.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Turn on the accessibility setting for reduced motion in the device settings, navigate around the app a bit, notice that things aren't sliding around.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1493 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
