### PR TITLE
Fix Sentry

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -6,6 +6,7 @@
     "app-toolbelt": "$(yarn bin app-toolbelt)"
   },
   "devDependencies": {
+    "@sentry/cli": "^3.4.0",
     "app-toolbelt": "github:digitalfabrik/app-toolbelt#semver:1.2.1"
   }
 }

--- a/tools/sentry-release
+++ b/tools/sentry-release
@@ -118,10 +118,7 @@ assign_positional_args 1 "${_positionals[@]}"
 set -e
 shopt -s nullglob
 
-if ! command -v sentry-cli &> /dev/null
-then
-  curl -sL https://sentry.io/get-cli/ | bash
-fi
+script_directory="$(dirname "$0")"
 
 package_name=$_arg_package_name
 version_name=$_arg_version_name
@@ -131,9 +128,21 @@ sourcemap_directory=$_arg_sourcemap_directory
 
 if [ -z "$SENTRY_AUTH_TOKEN" ]
 then
-  echo "SENTRY_AUTH_TOKEN is not set"
-  exit 1
+  echo "WARNING: SENTRY_AUTH_TOKEN is not set, skipping the sentry release"
+  exit 0
 fi
+
+sentry_cli="$(yarn --cwd "$script_directory" bin sentry-cli)" || true
+
+if [ ! -x "$sentry_cli" ]
+then
+  echo "WARNING: could not find sentry-cli in the tools dependencies, skipping the sentry release"
+  exit 0
+fi
+
+# sentry-cli only honours the url from .sentryclirc if the auth token comes from that same file. In CI
+# the token is an environment variable, so the url has to be passed as one as well.
+export SENTRY_URL="$(sed -n 's/^url=//p' "$script_directory/../.sentryclirc")"
 
 version="${package_name}@${version_name}"
 
@@ -144,8 +153,9 @@ then
 fi
 
 
-sentry-cli releases new "$version" --finalize
+"$sentry_cli" releases new "$version" --finalize || echo "WARNING: could not create the sentry release $version"
 
-sentry-cli sourcemaps upload --release="$version" --dist "$version_code" "$sourcemap_directory"
+"$sentry_cli" sourcemaps upload --release="$version" --dist "$version_code" "$sourcemap_directory" ||
+  echo "WARNING: could not upload sourcemaps, stack traces for $version will not be readable"
 
 # ] <-- needed because of Argbash

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -1569,6 +1569,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tools@workspace:."
   dependencies:
+    "@sentry/cli": ^3.4.0
     app-toolbelt: "github:digitalfabrik/app-toolbelt#semver:1.2.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Our latest test release failed because of a minor Sentry release that handles auth tokens differently. It only accepts a Sentry URL (which we need because ours is self-hosted) if it's handed in from the same source as the auth token. We hand in the token as an environment variable in CircleCI, so the newer release went looking for a Sentry URL, didn't find one, and went for the default one, where our token doesn't exist.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Instead of just taking the newest Sentry version, we set the version in the package.json
- Make the Sentry URL also an environment variable
- Let the release continue even if the Sentry upload fails, I think we can handle Sentry being marginally less useful

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Hope for the best?

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: https://app.circleci.com/pipelines/gh/digitalfabrik/lunes-app/4763/details?useNewPipelines=true&workflowId=fa828317-fcee-432d-8130-f94836acffc7#step-114-

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
