### PR TITLE
Show alternative words again

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,4 @@ ios/**/*
 version.json
 
 src/coverage/**
+_manifest/**

--- a/src/services/CmsApi.ts
+++ b/src/services/CmsApi.ts
@@ -142,20 +142,27 @@ type WordResponse = {
   article: CMSArticle
   images: string[]
   audio: string
+  alternative_words: {
+    alt_word: string
+    article: CMSArticle
+  }[]
   example_sentence: string | null
   example_sentence_audio: string | null
   pronunciation: string
 }
 
 const transformWordResponse = (response: WordResponse): StandardVocabularyItem => {
-  const { id, word, article, images, audio, pronunciation } = response
+  const { id, word, article, images, audio, pronunciation, alternative_words: alternativeWords } = response
   return {
     id: { type: VocabularyItemTypes.Standard, id },
     word,
     article: CMSArticleToArticle[article],
     images,
     audio,
-    alternatives: [],
+    alternatives: alternativeWords.map(({ alt_word: altWord, article: altArticle }) => ({
+      word: altWord,
+      article: CMSArticleToArticle[altArticle],
+    })),
     // The CMS sends an empty string for words that need no special pronunciation
     pronunciation: pronunciation || undefined,
     exampleSentence:


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Re-enable displaying alternative words in exercises. 
Alternative words are still not displayed in the "suche" tab, as before.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update the cms endpoint definition to include the new alternative words section

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Exercises display alternative words again
- Searching for an alternative words should work again

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Right now the production cms does not yet have the updated api, but the test cms works. 
Make sure that alternative words get displayed in the search screen (only when searching for them) and in exercises.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1501 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
