### PR TITLE
1099: Persist only file names of user vocabulary images and audio

### DIFF
--- a/release-notes/unreleased/1099-user-vocabulary-files.yml
+++ b/release-notes/unreleased/1099-user-vocabulary-files.yml
@@ -1,0 +1,6 @@
+issue_key: 1099
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Bilder und Audioaufnahmen eigener Vokabeln gehen nach einem App-Update nicht mehr verloren.

--- a/src/routes/process-user-vocabulary/UserVocabularyProcessScreen.tsx
+++ b/src/routes/process-user-vocabulary/UserVocabularyProcessScreen.tsx
@@ -1,4 +1,4 @@
-import { DocumentDirectoryPath, moveFile, unlink } from '@dr.pogodin/react-native-fs'
+import { moveFile, unlink } from '@dr.pogodin/react-native-fs'
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { ReactElement, useEffect, useState } from 'react'
@@ -18,6 +18,7 @@ import { ARTICLES, ArticleTypeExtended, BUTTONS_THEME, getArticleWithLabel } fro
 import { useStorageCache } from '../../hooks/useStorage'
 import { UserVocabularyId } from '../../models/VocabularyItem'
 import { RoutesParams } from '../../navigation/NavigationTypes'
+import { getUserVocabularyFileUri } from '../../services/Storage'
 import { getLabels } from '../../services/helpers'
 import { reportError } from '../../services/sentry'
 import {
@@ -139,14 +140,14 @@ const UserVocabularyProcessScreen = ({ navigation, route }: UserVocabularyProces
             path = image
           } else {
             const timestamp = Date.now()
-            path = `file:///${DocumentDirectoryPath}/image-${id.index}-${index}-${timestamp}.jpg`
+            path = getUserVocabularyFileUri(`image-${id.index}-${index}-${timestamp}.jpg`)
             await moveFile(image, path)
           }
           return path
         }),
       )
 
-      const audioPath = `file:///${DocumentDirectoryPath}/audio-${id.index}`
+      const audioPath = getUserVocabularyFileUri(`audio-${id.index}`)
       const audioPathWithFormat = Platform.OS === 'ios' ? `${audioPath}.m4a` : `${audioPath}.mp4`
 
       if (recordingPath) {

--- a/src/routes/process-user-vocabulary/__tests__/UserVocabularyProcessScreen.spec.tsx
+++ b/src/routes/process-user-vocabulary/__tests__/UserVocabularyProcessScreen.spec.tsx
@@ -42,10 +42,10 @@ describe('UserVocabularyProcessScreen', () => {
     word: 'Auto',
     article: ARTICLES[3],
     images: [
-      `file:///${ReactNativeFS.DocumentDirectoryPath}/image-2-0-2000.jpg`,
-      `file:///${ReactNativeFS.DocumentDirectoryPath}/image-2-1-2000.jpg`,
+      `file://${ReactNativeFS.DocumentDirectoryPath}/image-2-0-2000.jpg`,
+      `file://${ReactNativeFS.DocumentDirectoryPath}/image-2-1-2000.jpg`,
     ],
-    audio: `file:///${ReactNativeFS.DocumentDirectoryPath}/audio-2.m4a`,
+    audio: `file://${ReactNativeFS.DocumentDirectoryPath}/audio-2.m4a`,
     alternatives: [],
   }
   const navigation = createNavigationMock<'UserVocabularyProcess'>()

--- a/src/services/Storage.tsx
+++ b/src/services/Storage.tsx
@@ -1,3 +1,4 @@
+import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import React, { createContext, ReactElement } from 'react'
 
@@ -9,7 +10,7 @@ import { WordNodeCard } from './RepetitionService'
 import { CMS } from './axios'
 import { migrateStorage } from './storageUtils'
 
-export const STORAGE_VERSION = 6
+export const STORAGE_VERSION = 7
 
 export type Storage = {
   // Goes from 1 to STORAGE_VERSION and is incremented for each new required migration.
@@ -76,16 +77,52 @@ export const storageKeys: Record<StorageKey, string> = {
 
 export type StorageValue = (typeof storageKeys)[keyof typeof storageKeys]
 
+export const getFileName = (path: string): string => path.substring(path.lastIndexOf('/') + 1)
+
+// Images and audio recordings of user vocabulary items are stored in the document directory of the app.
+// Its absolute path may change between app updates (e.g. on iOS), therefore only the file names are persisted
+// and resolved to absolute uris when loading the storage.
+// See https://github.com/digitalfabrik/lunes-app/issues/1099
+export const getUserVocabularyFileUri = (fileName: string): string => `file://${DocumentDirectoryPath}/${fileName}`
+
+const mapUserVocabularyFiles = (
+  userVocabulary: UserVocabularyItem[],
+  mapFile: (file: string) => string,
+): UserVocabularyItem[] =>
+  userVocabulary.map(item => ({
+    ...item,
+    images: item.images.map(mapFile),
+    audio: item.audio ? mapFile(item.audio) : null,
+  }))
+
+type StorageSerializer<T extends StorageKey> = {
+  // Converts the value of the storage cache to the persisted value
+  serialize: (value: Storage[T]) => Storage[T]
+  // Converts the persisted value to the value of the storage cache
+  deserialize: (value: Storage[T]) => Storage[T]
+}
+
+const storageSerializers: { [T in StorageKey]?: StorageSerializer<T> } = {
+  userVocabulary: {
+    serialize: userVocabulary => mapUserVocabularyFiles(userVocabulary, getFileName),
+    deserialize: userVocabulary => mapUserVocabularyFiles(userVocabulary, getUserVocabularyFileUri),
+  },
+}
+
 export const getStorageItemOr = async <T,>(key: StorageValue, defaultValue: T): Promise<T> => {
   const value = await AsyncStorage.getItem(key)
   return value ? JSON.parse(value) : defaultValue
 }
 
-export const getStorageItem = async <T extends StorageKey>(key: T): Promise<Storage[T]> =>
-  getStorageItemOr(storageKeys[key], defaultStorage[key])
+export const getStorageItem = async <T extends StorageKey>(key: T): Promise<Storage[T]> => {
+  const value = await getStorageItemOr(storageKeys[key], defaultStorage[key])
+  const serializer = storageSerializers[key]
+  return serializer ? serializer.deserialize(value) : value
+}
 
 const setStorageItem = async <T extends StorageKey>(key: T, value: Storage[T]): Promise<void> => {
-  await AsyncStorage.setItem(storageKeys[key], JSON.stringify(value))
+  const serializer = storageSerializers[key]
+  await AsyncStorage.setItem(storageKeys[key], JSON.stringify(serializer ? serializer.serialize(value) : value))
 }
 
 // https://github.com/react-native-async-storage/async-storage/issues/401#issuecomment-2508924008

--- a/src/services/__tests__/Storage.spec.ts
+++ b/src/services/__tests__/Storage.spec.ts
@@ -1,5 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
+import { ARTICLES } from '../../constants/data'
+import { UserVocabularyItem, VocabularyItemTypes } from '../../models/VocabularyItem'
 import { getStorageItem, loadStorageCache, storageKeys } from '../Storage'
 
 describe('Storage', () => {
@@ -39,5 +41,40 @@ describe('Storage', () => {
     removeListener()
     await storageCache.setItem('analyticsConsent', { consentGiven: true, consentDate: '2024-01-01' })
     expect(listenerCalls).toBe(2)
+  })
+
+  describe('userVocabulary', () => {
+    const persistedItem = {
+      id: { index: 1, type: VocabularyItemTypes.UserCreated },
+      word: 'Hund',
+      article: ARTICLES[1],
+      images: ['image-1-0-2000.jpg', 'image-1-1-2000.jpg'],
+      audio: 'audio-1.m4a',
+      alternatives: [],
+    }
+    const loadedItem: UserVocabularyItem = {
+      ...persistedItem,
+      images: [
+        'file://mock-document-directory-path/image-1-0-2000.jpg',
+        'file://mock-document-directory-path/image-1-1-2000.jpg',
+      ],
+      audio: 'file://mock-document-directory-path/audio-1.m4a',
+    }
+
+    it('Should resolve file names of images and audio to uris when loading', async () => {
+      await AsyncStorage.setItem(storageKeys.userVocabulary, JSON.stringify([persistedItem]))
+      const storageCache = await loadStorageCache()
+      expect(storageCache.getItem('userVocabulary')).toEqual([loadedItem])
+    })
+
+    it('Should persist only the file names of images and audio', async () => {
+      const storageCache = await loadStorageCache()
+      await storageCache.setItem('userVocabulary', [loadedItem])
+      expect(storageCache.getItem('userVocabulary')).toEqual([loadedItem])
+      await expect(AsyncStorage.getItem(storageKeys.userVocabulary)).resolves.toEqual(JSON.stringify([persistedItem]))
+
+      const newStorageCache = await loadStorageCache()
+      expect(newStorageCache.getItem('userVocabulary')).toEqual([loadedItem])
+    })
   })
 })

--- a/src/services/__tests__/storageUtils.spec.ts
+++ b/src/services/__tests__/storageUtils.spec.ts
@@ -285,7 +285,7 @@ describe('storageUtils', () => {
             id: { index: 1, type: VocabularyItemTypes.UserCreated },
             word: 'Testwort',
             article: { id: 3, value: 'das' },
-            images: ['image-1'],
+            images: ['file://mock-document-directory-path/image-1'],
             audio: null,
             alternatives: [],
           },
@@ -293,7 +293,7 @@ describe('storageUtils', () => {
             id: { index: 2, type: VocabularyItemTypes.UserCreated },
             word: 'Hund',
             article: { id: 1, value: 'der' },
-            images: ['image-2'],
+            images: ['file://mock-document-directory-path/image-2'],
             audio: null,
             alternatives: [],
           },
@@ -479,6 +479,60 @@ describe('storageUtils', () => {
       })
     })
 
+    describe('should migrate from v6', () => {
+      it('should replace absolute paths of user vocabulary images and audio with file names', async () => {
+        await AsyncStorage.setItem(storageKeys.version, '6')
+        const oldDocumentDirectoryPath = 'file:///var/mobile/Containers/Data/Application/old-uuid/Documents'
+        const hund = {
+          id: { index: 1, type: VocabularyItemTypes.UserCreated },
+          word: 'Hund',
+          article: { id: 1, value: 'der' },
+          alternatives: [],
+        }
+        const katze = { ...hund, id: { index: 2, type: VocabularyItemTypes.UserCreated }, word: 'Katze' }
+        await AsyncStorage.setItem(
+          'userVocabulary',
+          JSON.stringify([
+            {
+              ...hund,
+              images: [`${oldDocumentDirectoryPath}/image-1-0-2000.jpg`],
+              audio: `${oldDocumentDirectoryPath}/audio-1.m4a`,
+            },
+            {
+              ...katze,
+              images: [
+                `${oldDocumentDirectoryPath}/image-2-0-2000.jpg`,
+                `${oldDocumentDirectoryPath}/image-2-1-2000.jpg`,
+              ],
+              audio: null,
+            },
+          ]),
+        )
+
+        const storageCache = await loadStorageCache()
+
+        expect(JSON.parse((await AsyncStorage.getItem('userVocabulary'))!)).toEqual([
+          { ...hund, images: ['image-1-0-2000.jpg'], audio: 'audio-1.m4a' },
+          { ...katze, images: ['image-2-0-2000.jpg', 'image-2-1-2000.jpg'], audio: null },
+        ])
+        expect(storageCache.getItem('userVocabulary')).toEqual([
+          {
+            ...hund,
+            images: ['file://mock-document-directory-path/image-1-0-2000.jpg'],
+            audio: 'file://mock-document-directory-path/audio-1.m4a',
+          },
+          {
+            ...katze,
+            images: [
+              'file://mock-document-directory-path/image-2-0-2000.jpg',
+              'file://mock-document-directory-path/image-2-1-2000.jpg',
+            ],
+            audio: null,
+          },
+        ])
+      })
+    })
+
     describe('when version is unset and data is already fully migrated', () => {
       const alreadyMigratedWordNodeCard = {
         wordId: { type: VocabularyItemTypes.Standard, id: 1 },
@@ -515,7 +569,12 @@ describe('storageUtils', () => {
 
         const storageCache = await loadStorageCache()
 
-        expect(storageCache.getItem('userVocabulary')).toEqual([alreadyMigratedUserVocabularyItem])
+        await expect(AsyncStorage.getItem('userVocabulary')).resolves.toEqual(
+          JSON.stringify([alreadyMigratedUserVocabularyItem]),
+        )
+        expect(storageCache.getItem('userVocabulary')).toEqual([
+          { ...alreadyMigratedUserVocabularyItem, images: ['file://mock-document-directory-path/image-1'] },
+        ])
       })
 
       it('should pass through favorites unchanged', async () => {

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -16,7 +16,7 @@ import { generateUniqueId, trackEvent } from './AnalyticsService'
 import { getWordsByJob } from './CmsApi'
 import { RepetitionService } from './RepetitionService'
 import type { WordNodeCard } from './RepetitionService'
-import { getStorageItem, getStorageItemOr, STORAGE_VERSION, StorageCache } from './Storage'
+import { getFileName, getStorageItem, getStorageItemOr, STORAGE_VERSION, StorageCache } from './Storage'
 import { CMS_URLS } from './axios'
 import { calculateScore } from './helpers'
 
@@ -310,6 +310,20 @@ export const migrate5To6 = async (): Promise<void> => {
   await AsyncStorage.setItem('progress', JSON.stringify(migratedProgress))
 }
 
+// Replaces the absolute paths of user vocabulary images and audio recordings with their file names,
+// since the absolute path of the document directory may change between app updates
+export const migrate6To7 = async (): Promise<void> => {
+  type OldUserVocabularyItem = Incomplete<{ images: string[]; audio?: string | null }>
+
+  const oldUserVocabulary = await getStorageItemOr<OldUserVocabularyItem[]>('userVocabulary', [])
+  const newUserVocabulary = oldUserVocabulary.map(item => ({
+    ...item,
+    images: item.images.map(getFileName),
+    audio: item.audio ? getFileName(item.audio) : null,
+  }))
+  await AsyncStorage.setItem('userVocabulary', JSON.stringify(newUserVocabulary))
+}
+
 // Removes the cms url overwrite value in case it has changed between versions
 export const migrateApiEndpointUrl = async (): Promise<void> => {
   const overwrite = await AsyncStorage.getItem('cms')
@@ -353,6 +367,9 @@ export const migrateStorage = async (): Promise<void> => {
     // eslint-disable-next-line no-fallthrough, no-magic-numbers
     case 5:
       await migrate5To6()
+    // eslint-disable-next-line no-fallthrough, no-magic-numbers
+    case 6:
+      await migrate6To7()
       break
   }
 


### PR DESCRIPTION
### Short Description

Images and audio recordings of user vocabulary items were stored with the absolute path of the document directory, which changes between app updates on iOS. Only file names are persisted now and resolved to absolute uris when loading the storage.

### Proposed Changes

- Add a `userVocabulary` storage serializer in `Storage.tsx` that strips paths to file names on persist and resolves them via `DocumentDirectoryPath` on load
- Add storage migration 6 → 7 converting existing absolute paths to file names
- Build new image/audio paths in `UserVocabularyProcessScreen` via the shared `getUserVocabularyFileUri` helper

### Side Effects

- In-memory `userVocabulary` items still hold absolute `file://` uris, so consumers (exercises, list, edit/delete) are unchanged

### Testing

- Create a user vocabulary item with images and audio, reinstall/update the app (iOS), images and audio should still be shown
- Edit and delete an existing item, files should be replaced/removed correctly

### Resolved Issues

Fixes: #1099