### PR TITLE
Fix the screenshot workflow

### DIFF
--- a/.maestro/screenshots.yaml
+++ b/.maestro/screenshots.yaml
@@ -33,9 +33,9 @@ name: Lunes store screenshots
     repeat: 6
 - tapOn: 'Development Code'
 - inputText: 'wirschaffendas'
-- hideKeyboard
 - tapOn:
     id: 'debug-seed-screenshot-data'
+    repeat: 2
 - tapOn: 'Schließen'
 
 # 01 — Home tab with seeded selected jobs.
@@ -51,8 +51,7 @@ name: Lunes store screenshots
 
 # Open the unit list (UnitSelection) for the first job.
 - tapOn:
-    text: 'Übung starten'
-    index: 0
+    id: 'start-learning-button'
 - extendedWaitUntil:
     notVisible:
       id: 'loading'
@@ -106,9 +105,9 @@ name: Lunes store screenshots
 - tapOn:
     text: 'Start.*'
     repeat: 2
+- scroll
 - tapOn:
-    text: 'Übung starten'
-    index: 1
+    id: 'start-training-button'
 - extendedWaitUntil:
     notVisible:
       id: 'loading'

--- a/.maestro/screenshots.yaml
+++ b/.maestro/screenshots.yaml
@@ -33,9 +33,9 @@ name: Lunes store screenshots
     repeat: 6
 - tapOn: 'Development Code'
 - inputText: 'wirschaffendas'
+- hideKeyboard
 - tapOn:
     id: 'debug-seed-screenshot-data'
-    repeat: 2
 - tapOn: 'Schließen'
 
 # 01 — Home tab with seeded selected jobs.

--- a/src/routes/home/components/ModeSelection.tsx
+++ b/src/routes/home/components/ModeSelection.tsx
@@ -134,6 +134,7 @@ const LearningCard = ({ numberUnits, unitsCompleted, color, onPress }: LearningC
           <ProgressBar progress={unitsCompleted / numberUnits} />
         </ProgressBarTrack>
         <StartButton
+          testID='start-learning-button'
           onPress={onPress}
           label={labels.home.startExercise}
           buttonTheme={BUTTONS_THEME.contained}
@@ -173,6 +174,7 @@ const TrainingCard = ({ onPress }: TrainingCardProps): ReactElement => {
           )}
         </BadgeRow>
         <StartButton
+          testID='start-training-button'
           onPress={onPress}
           label={labels.startExercise}
           buttonTheme={BUTTONS_THEME.contained}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fixes the problem on ios and also a local issue I encountered on android

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add a scroll instruction to make sure that the training button is clickable (Before it was on screen, but hidden behind the navigation buttons, which caused the app to go to the wrong screen)
- Give the learning and exercise buttons test ids to make the workflow a bit more robust
- On android, the `hideKeyboard` also dismissed the popup, so I replaced it with a double click on the expected button (first click to dismiss the keyboard)


### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
test the android and ios screenshots (I'll also let a CI workflow run)
The workflow was now successful (#1512)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1503 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
