### PR TITLE
1513: Update iOS screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,11 +509,6 @@ jobs:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
             xcode: 26.3.0
-        parameters:
-            production_delivery:
-                default: false
-                description: Whether to deliver the build to production.
-                type: boolean
         shell: /bin/bash --login -o pipefail
         steps:
             - checkout
@@ -526,20 +521,10 @@ jobs:
                 command: yarn app-toolbelt v0 release-notes prepare-metadata lunes appstore ../ios/fastlane/metadata/
                 name: Parse german ios release notes
                 working_directory: tools
-            - when:
-                condition: << parameters.production_delivery >>
-                steps:
-                    - run:
-                        command: bundle exec fastlane ios upload_to_appstoreconnect ipa_path:attached_workspace/app-release.ipa version_name:${NEW_VERSION_NAME}
-                        name: '[FL] App Store Connect Upload'
-                        working_directory: ios
-            - unless:
-                condition: << parameters.production_delivery >>
-                steps:
-                    - run:
-                        command: bundle exec fastlane upload_to_test_flight ipa_path:attached_workspace/app-release.ipa
-                        name: '[FL] TestFlight Upload'
-                        working_directory: ios
+            - run:
+                command: bundle exec fastlane upload_to_test_flight ipa_path:attached_workspace/app-release.ipa
+                name: '[FL] TestFlight Upload'
+                working_directory: ios
             - run:
                 command: tools/sentry-release "app.lunes" "${NEW_VERSION_NAME}" ~/attached_workspace/sourcemaps/ --version-code "${NEW_VERSION_CODE}"
                 name: Sentry Upload
@@ -789,11 +774,11 @@ jobs:
             - install_maestro
             - run:
                 command: |
-                    xcrun simctl boot "iPhone 16 Pro" || true
-                    xcrun simctl bootstatus "iPhone 16 Pro" -b
+                    xcrun simctl boot "iPhone 17 Pro Max" || true
+                    xcrun simctl bootstatus "iPhone 17 Pro Max" -b
                 name: Boot simulator
             - run:
-                command: yarn ios:production --simulator "iPhone 16 Pro"
+                command: yarn ios:production --simulator "iPhone 17 Pro Max"
                 name: Build and install release app on simulator
             - run:
                 command: yarn screenshots:ios
@@ -953,7 +938,6 @@ workflows:
                     - mattermost
                     - tuerantuer-apple
                     - sentry
-                production_delivery: false
                 requires:
                     - build_ios
             - notify_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,10 +518,6 @@ jobs:
             - restore_ruby_cache:
                 directory: ios
             - run:
-                command: yarn app-toolbelt v0 release-notes prepare-metadata lunes appstore ../ios/fastlane/metadata/
-                name: Parse german ios release notes
-                working_directory: tools
-            - run:
                 command: bundle exec fastlane upload_to_test_flight ipa_path:attached_workspace/app-release.ipa
                 name: '[FL] TestFlight Upload'
                 working_directory: ios
@@ -760,6 +756,7 @@ jobs:
     screenshot_ios:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
+            SIMULATOR_DEVICE: iPhone 17 Pro Max
             TOTAL_CPUS: 6
         macos:
             xcode: 26.3.0
@@ -774,11 +771,11 @@ jobs:
             - install_maestro
             - run:
                 command: |
-                    xcrun simctl boot "iPhone 17 Pro Max" || true
-                    xcrun simctl bootstatus "iPhone 17 Pro Max" -b
+                    xcrun simctl boot "$SIMULATOR_DEVICE" || true
+                    xcrun simctl bootstatus "$SIMULATOR_DEVICE" -b
                 name: Boot simulator
             - run:
-                command: yarn ios:production --simulator "iPhone 17 Pro Max"
+                command: yarn ios:production --simulator "$SIMULATOR_DEVICE"
                 name: Build and install release app on simulator
             - run:
                 command: yarn screenshots:ios

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -11,10 +11,6 @@ steps:
   - restore_ruby_cache:
       directory: ios
   - run:
-      name: Parse german ios release notes
-      command: yarn app-toolbelt v0 release-notes prepare-metadata lunes appstore ../ios/fastlane/metadata/
-      working_directory: tools
-  - run:
       name: '[FL] TestFlight Upload'
       command: bundle exec fastlane upload_to_test_flight ipa_path:attached_workspace/app-release.ipa
       working_directory: ios

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -1,8 +1,3 @@
-parameters:
-  production_delivery:
-    description: Whether to deliver the build to production.
-    type: boolean
-    default: false
 macos:
   xcode: 26.3.0
 environment:
@@ -19,20 +14,10 @@ steps:
       name: Parse german ios release notes
       command: yarn app-toolbelt v0 release-notes prepare-metadata lunes appstore ../ios/fastlane/metadata/
       working_directory: tools
-  - when:
-      condition: << parameters.production_delivery >>
-      steps:
-        - run:
-            name: '[FL] App Store Connect Upload'
-            command: bundle exec fastlane ios upload_to_appstoreconnect ipa_path:attached_workspace/app-release.ipa version_name:${NEW_VERSION_NAME}
-            working_directory: ios
-  - unless:
-      condition: << parameters.production_delivery >>
-      steps:
-        - run:
-            name: '[FL] TestFlight Upload'
-            command: bundle exec fastlane upload_to_test_flight ipa_path:attached_workspace/app-release.ipa
-            working_directory: ios
+  - run:
+      name: '[FL] TestFlight Upload'
+      command: bundle exec fastlane upload_to_test_flight ipa_path:attached_workspace/app-release.ipa
+      working_directory: ios
   - run:
       name: Sentry Upload
       command: tools/sentry-release "app.lunes" "${NEW_VERSION_NAME}" ~/attached_workspace/sourcemaps/ --version-code "${NEW_VERSION_CODE}"

--- a/.circleci/src/jobs/screenshot_ios.yml
+++ b/.circleci/src/jobs/screenshot_ios.yml
@@ -16,11 +16,11 @@ steps:
   - run:
       name: Boot simulator
       command: |
-        xcrun simctl boot "iPhone 16 Pro" || true
-        xcrun simctl bootstatus "iPhone 16 Pro" -b
+        xcrun simctl boot "iPhone 17 Pro Max" || true
+        xcrun simctl bootstatus "iPhone 17 Pro Max" -b
   - run:
       name: Build and install release app on simulator
-      command: yarn ios:production --simulator "iPhone 16 Pro"
+      command: yarn ios:production --simulator "iPhone 17 Pro Max"
   - run:
       name: Capture screenshots
       command: yarn screenshots:ios

--- a/.circleci/src/jobs/screenshot_ios.yml
+++ b/.circleci/src/jobs/screenshot_ios.yml
@@ -5,6 +5,7 @@ resource_class: m4pro.medium
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
   TOTAL_CPUS: 6
+  SIMULATOR_DEVICE: iPhone 17 Pro Max
 shell: /bin/bash --login -o pipefail
 steps:
   - checkout
@@ -16,11 +17,11 @@ steps:
   - run:
       name: Boot simulator
       command: |
-        xcrun simctl boot "iPhone 17 Pro Max" || true
-        xcrun simctl bootstatus "iPhone 17 Pro Max" -b
+        xcrun simctl boot "$SIMULATOR_DEVICE" || true
+        xcrun simctl bootstatus "$SIMULATOR_DEVICE" -b
   - run:
       name: Build and install release app on simulator
-      command: yarn ios:production --simulator "iPhone 17 Pro Max"
+      command: yarn ios:production --simulator "$SIMULATOR_DEVICE"
   - run:
       name: Capture screenshots
       command: yarn screenshots:ios

--- a/.circleci/src/workflows/dev_delivery.yml
+++ b/.circleci/src/workflows/dev_delivery.yml
@@ -37,7 +37,6 @@ jobs:
         - mattermost
         - tuerantuer-apple
         - sentry
-      production_delivery: false
       requires:
         - build_ios
   - notify_github:

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -41,7 +41,7 @@ All screenshots are taken on an iPhone 17 Pro Max, because the App Store require
 To take the screenshots:
 
 1. Start the simulator
-2. Build the app with `yarn ios:production`
+2. Build the app with `yarn ios:production --simulator "iPhone 17 Pro Max"`
 3. Take the screenshots with `yarn screenshots:ios`
 
 ## In CI

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -37,7 +37,7 @@ Then to take the screenshots:
 
 ### iOS
 
-All screenshots are taken on an iPhone 16 Pro.
+All screenshots are taken on an iPhone 17 Pro Max, because the App Store requires the 6.9" display size.
 To take the screenshots:
 
 1. Start the simulator

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -165,7 +165,9 @@ platform :ios do
       automatic_release: true,
       force: true,
       skip_metadata: false,
-      skip_screenshots: true,
+      skip_screenshots: false,
+      # App Store Connect copies the previous version's screenshots into the new one, so they have to be replaced
+      overwrite_screenshots: true,
       skip_binary_upload: true,
       metadata_path: "./fastlane/metadata",
       precheck_include_in_app_purchases: false, # We do not have inapp purchases

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -86,39 +86,6 @@ platform :ios do
     File.write("browserstack_live_url", ios_url)
   end
 
-  # The following parameters have to be passed:
-  # version_name: The version name of the app
-  # ipa_path: The path of the ipa to upload (relative to home dir)
-  desc "Deliver the app to App Store Connect. The app is submitted for review and released automatically."
-  lane :upload_to_appstoreconnect do |options|
-    apple_auth()
-
-    version_name = options[:version_name]
-    ipa_path = options[:ipa_path]
-
-    if [version_name, ipa_path].include?(nil)
-      raise "'nil' passed as parameter! Aborting..."
-    end
-
-    puts("delivering v#{version_name}")
-
-    # https://docs.fastlane.tools/actions/deliver/
-    deliver(
-      ipa: "#{ENV['HOME']}/#{ipa_path}",
-      app_version: version_name,
-      submit_for_review: true,
-      automatic_release: true,
-      force: true,
-      skip_screenshots: false,
-      skip_metadata: false,
-      skip_app_version_update: false,
-      metadata_path: "./fastlane/metadata",
-      precheck_include_in_app_purchases: false, # We do not have inapp purchases
-      submission_information: { add_id_info_uses_idfa: false } # https://firebase.google.com/docs/analytics/configure-data-collection?platform=ios
-    # https://support.google.com/firebase/answer/6318039?hl=en
-    )
-  end
-
   desc "Deliver iOS App to TestFlight for testers"
   lane :upload_to_test_flight do |options|
     apple_auth()

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -31,14 +31,6 @@ Create a release build
 
 Upload iOS App to BrowserStack
 
-### ios upload_to_appstoreconnect
-
-```sh
-[bundle exec] fastlane ios upload_to_appstoreconnect
-```
-
-Deliver the app to App Store Connect. The app is submitted for review and released automatically.
-
 ### ios upload_to_test_flight
 
 ```sh


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Turns out we never actually updated the iOS screenshots, this PR fixes that.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- Set `skip_screenshots` to false in the iOS Fastfile
- Update the phone to use for the screenshot to an iPhone 17 Pro Max because that matches the required size for the default screenshots on the App Store (the rest can be sized up or down from those)
- Removed some dead code

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- We need to run the pipeline to update the screenshots before the next release, otherwise we might get empty screenshots (if Apple really is that strict about the screenshot sizing).

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Next release?

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1513 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
