### PR TITLE
1516: upload the screenshots again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ commands:
         steps:
             - run:
                 command: |
-                    curl -fsSL "https://get.maestro.mobile.dev" | bash
+                    # Pinned: takeScreenshot's output location moves between Maestro releases
+                    curl -fsSL "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.9.0 bash
                     echo 'export PATH="$HOME/.maestro/bin:$PATH"' >> "$BASH_ENV"
                 name: Install Maestro
     notify:
@@ -637,17 +638,22 @@ jobs:
             - checkout
             - attach_workspace:
                 at: .
+            - run:
+                command: |
+                    # app-toolbelt commits the files it is passed even when that leaves the tree identical to the base
+                    if [ -n "$(git status --porcelain -- android/fastlane/metadata/de-DE/images/phoneScreenshots ios/fastlane/screenshots/de-DE)" ]; then
+                      exit 0
+                    fi
+                    echo "Screenshots are unchanged, nothing to open a pull request for"
+                    circleci-agent step halt
+                name: Skip unchanged screenshots
             - restore_yarn_tools_cache
             - run:
                 command: |
-                    FILES=$(ls android/fastlane/metadata/de-DE/images/phoneScreenshots/*.png ios/fastlane/screenshots/de-DE/*.png 2>/dev/null)
-                    count=$(echo "$FILES" | wc -w)
-                    if [ "$count" -eq 0 ]; then
-                      echo "No screenshots produced, nothing to commit"
-                      exit 1
-                    fi
                     # app-toolbelt commits files at the exact paths passed, so run from repo root (don't cd into tools)
-                    "$(yarn --cwd tools bin app-toolbelt)" v0 pr open-pr $FILES \
+                    "$(yarn --cwd tools bin app-toolbelt)" v0 pr open-pr \
+                      android/fastlane/metadata/de-DE/images/phoneScreenshots/*.png \
+                      ios/fastlane/screenshots/de-DE/*.png \
                       --private-key "${DELIVERINO_PRIVATE_KEY}" \
                       --owner "${CIRCLE_PROJECT_USERNAME}" \
                       --repo "${CIRCLE_PROJECT_REPONAME}" \

--- a/.circleci/src/commands/install_maestro.yml
+++ b/.circleci/src/commands/install_maestro.yml
@@ -3,5 +3,6 @@ steps:
   - run:
       name: Install Maestro
       command: |
-        curl -fsSL "https://get.maestro.mobile.dev" | bash
+        # Pinned: takeScreenshot's output location moves between Maestro releases
+        curl -fsSL "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.9.0 bash
         echo 'export PATH="$HOME/.maestro/bin:$PATH"' >> "$BASH_ENV"

--- a/.circleci/src/jobs/open_screenshots_pr.yml
+++ b/.circleci/src/jobs/open_screenshots_pr.yml
@@ -7,18 +7,23 @@ steps:
   - checkout
   - attach_workspace:
       at: . # at repo root so the PNG paths stay repo-relative
+  - run:
+      name: Skip unchanged screenshots
+      command: |
+        # app-toolbelt commits the files it is passed even when that leaves the tree identical to the base
+        if [ -n "$(git status --porcelain -- android/fastlane/metadata/de-DE/images/phoneScreenshots ios/fastlane/screenshots/de-DE)" ]; then
+          exit 0
+        fi
+        echo "Screenshots are unchanged, nothing to open a pull request for"
+        circleci-agent step halt
   - restore_yarn_tools_cache
   - run:
       name: Open screenshots PR
       command: |
-        FILES=$(ls android/fastlane/metadata/de-DE/images/phoneScreenshots/*.png ios/fastlane/screenshots/de-DE/*.png 2>/dev/null)
-        count=$(echo "$FILES" | wc -w)
-        if [ "$count" -eq 0 ]; then
-          echo "No screenshots produced, nothing to commit"
-          exit 1
-        fi
         # app-toolbelt commits files at the exact paths passed, so run from repo root (don't cd into tools)
-        "$(yarn --cwd tools bin app-toolbelt)" v0 pr open-pr $FILES \
+        "$(yarn --cwd tools bin app-toolbelt)" v0 pr open-pr \
+          android/fastlane/metadata/de-DE/images/phoneScreenshots/*.png \
+          ios/fastlane/screenshots/de-DE/*.png \
           --private-key "${DELIVERINO_PRIVATE_KEY}" \
           --owner "${CIRCLE_PROJECT_USERNAME}" \
           --repo "${CIRCLE_PROJECT_REPONAME}" \

--- a/.maestro/screenshots.yaml
+++ b/.maestro/screenshots.yaml
@@ -15,7 +15,7 @@ name: Lunes store screenshots
       id: 'loading'
     timeout: 15000
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/00_onboarding
+- takeScreenshot: 00_onboarding
 - tapOn: 'Überspringen'
 
 # Dismiss analytics-consent modal if it appears.
@@ -47,7 +47,7 @@ name: Lunes store screenshots
       id: 'loading'
     timeout: 15000
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/01_home
+- takeScreenshot: 01_home
 
 # Open the unit list (UnitSelection) for the first job.
 - tapOn:
@@ -77,7 +77,7 @@ name: Lunes store screenshots
 - tapOn:
     id: 'word-item'
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/02_word_choice
+- takeScreenshot: 02_word_choice
 - tapOn: 'Nächstes Wort'
 
 # Exit out of the exercise back to the home stack root.
@@ -93,12 +93,12 @@ name: Lunes store screenshots
       id: 'loading'
     timeout: 15000
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/03_dictionary
+- takeScreenshot: 03_dictionary
 
 # 04 — Repetition tab.
 - tapOn: 'Vertiefen(,.*)?'
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/04_repetition
+- takeScreenshot: 04_repetition
 
 # 05 — Image training exercise.
 # Two taps to reset to the home screen, one tap only goes back to the units screen
@@ -116,7 +116,7 @@ name: Lunes store screenshots
 - tapOn:
     id: 'imageOption'
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/05_image_training
+- takeScreenshot: 05_image_training
 
 - tapOn: 'Übung beenden'
 - tapOn: 'Beenden'
@@ -125,7 +125,7 @@ name: Lunes store screenshots
 # 06 — Speech training
 - tapOn: 'Sprechstudio.*'
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/06_speech_training
+- takeScreenshot: 06_speech_training
 
 - tapOn: 'Übung beenden'
 - tapOn: 'Beenden'
@@ -134,4 +134,4 @@ name: Lunes store screenshots
 # 07 — Sentence training
 - tapOn: 'Satzbausteine.*'
 - waitForAnimationToEnd
-- takeScreenshot: ${OUTPUT_DIR}/07_sentence_training
+- takeScreenshot: 07_sentence_training

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -18,6 +18,7 @@ One important note, Android only allows eight screenshots per language.
 To update the screenshots, the `maestro` command line tool needs to be installed.
 `maestro` is available via homebrew and nix, or can be downloaded directly.
 For more information, see the [docs](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
+Use the version CI pins in `.circleci/src/commands/install_maestro.yml`.
 
 ### Android
 

--- a/tools/screenshots-android
+++ b/tools/screenshots-android
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OUTPUT_DIR="android/fastlane/metadata/de-DE/images/phoneScreenshots"
-
 # Put SystemUI into demo mode so the status bar matches the iOS simulator's
 # pinned status bar. Mirrors AOSP's "Show demo mode" toggle (DemoModeFragment).
 DEMO="am broadcast -a com.android.systemui.demo"
@@ -18,4 +16,4 @@ adb shell $DEMO -e command notifications -e visible false
 # emulators when a text field is first focused — it would block inputText.
 adb shell settings put secure stylus_handwriting_enabled 0
 
-maestro --platform android test --env OUTPUT_DIR="$OUTPUT_DIR" .maestro/screenshots.yaml
+tools/screenshots-run android android/fastlane/metadata/de-DE/images/phoneScreenshots

--- a/tools/screenshots-ios
+++ b/tools/screenshots-ios
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OUTPUT_DIR="ios/fastlane/screenshots/de-DE"
-
 # Pin the simulator's status bar so screenshots are reproducible
 trap 'xcrun simctl status_bar booted clear' EXIT
 xcrun simctl status_bar booted override \
@@ -14,6 +12,4 @@ xcrun simctl status_bar booted override \
   --batteryState charged \
   --batteryLevel 100
 
-maestro --platform ios test \
-  --env OUTPUT_DIR="$OUTPUT_DIR" \
-  .maestro/screenshots.yaml
+tools/screenshots-run ios ios/fastlane/screenshots/de-DE

--- a/tools/screenshots-run
+++ b/tools/screenshots-run
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+PLATFORM="$1"
+OUTPUT_DIR="$2"
+
+# Maestro rejects takeScreenshot paths that point outside the run's own artifact bundle,
+# so the flow only names the files and we collect them from the bundle afterwards
+ARTIFACTS_DIR="$(mktemp -d)"
+trap 'rm -rf "$ARTIFACTS_DIR"' EXIT
+
+maestro --platform "$PLATFORM" test \
+  --debug-output "$ARTIFACTS_DIR" \
+  --flatten-debug-output \
+  .maestro/screenshots.yaml
+
+captured=("$ARTIFACTS_DIR"/*/takeScreenshot/*.png)
+expected=$(grep -c '^- takeScreenshot:' .maestro/screenshots.yaml)
+
+# Copying a partial capture over the previous set would still look complete to everyone downstream
+if [ "${#captured[@]}" -ne "$expected" ]; then
+  echo "Expected $expected screenshots, captured ${#captured[@]}."
+  exit 1
+fi
+
+rm -f "$OUTPUT_DIR"/*.png
+cp "${captured[@]}" "$OUTPUT_DIR"/


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR hopefully fixes the screenshots being uploaded.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Pin the maestro version so we don't get surprised by future changes that we don't notice
- Update the path flow for version 2.9.0
- Add a failure mode in if less than 8 screenshots are produced

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- We should manually update the maestro version every once in a while

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
1. Be on maestro 2.9.0
2. Remove the screenshots from /ios/fastlane/screenshots/de-DE
3. Run a prod build: `yarn ios:production --simulator "iPhone 17 Pro Max"`
4. Run `yarn screenshots:ios`
5. See that the screenshots are filled in.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1516 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
