### PR TITLE
1209: add personal notes to vocabulary

### DIFF
--- a/release-notes/unreleased/1209-vocabulary-notes.yml
+++ b/release-notes/unreleased/1209-vocabulary-notes.yml
@@ -1,0 +1,6 @@
+issue_key: 1209
+show_in_stores: true
+platforms:
+  - android
+  - ios
+de: Zu jeder Vokabel kann jetzt eine persönliche Notiz gespeichert werden.

--- a/src/components/AddVocabularyNoteButton.tsx
+++ b/src/components/AddVocabularyNoteButton.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement } from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { AddCircleIcon } from '../../assets/images'
+import { getLabels } from '../services/helpers'
+import PressableOpacity from './PressableOpacity'
+import { SubheadingPrimary } from './text/Subheading'
+
+const Row = styled(PressableOpacity)`
+  align-items: center;
+  gap: ${props => props.theme.spacings.xs};
+  padding: ${props => props.theme.spacings.sm} 0;
+`
+
+const Label = styled(SubheadingPrimary)`
+  font-size: ${props => props.theme.fonts.largeFontSize};
+`
+
+type AddVocabularyNoteButtonProps = {
+  onPress: () => void
+}
+
+const AddVocabularyNoteButton = ({ onPress }: AddVocabularyNoteButtonProps): ReactElement => {
+  const theme = useTheme()
+  const { add } = getLabels().notes
+
+  return (
+    <Row onPress={onPress} accessibilityLabel={add}>
+      <AddCircleIcon width={theme.spacingsPlain.md} height={theme.spacingsPlain.md} color={theme.colors.primary} />
+      <Label>{add}</Label>
+    </Row>
+  )
+}
+
+export default AddVocabularyNoteButton

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,6 +6,7 @@ import styled, { css, useTheme } from 'styled-components/native'
 import { BUTTONS_THEME, ButtonTheme } from '../constants/data'
 import { Color } from '../constants/theme/colors'
 import { Subheading } from './text/Subheading'
+import { uppercase } from './text/uppercase'
 
 const BUTTON_WIDTH_RATIO = 0.7
 
@@ -51,8 +52,7 @@ const ThemedButton = styled.Pressable<ThemedButtonProps>`
 export const Label = styled(Subheading)<ThemedLabelProps>`
   color: ${props => props.color};
   text-align: center;
-  letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
-  text-transform: uppercase;
+  ${uppercase};
   padding: ${props => `0 ${props.theme.spacings.xs}`};
 `
 

--- a/src/components/CircularIconButton.tsx
+++ b/src/components/CircularIconButton.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement, ReactNode } from 'react'
+import { StyleProp, ViewStyle } from 'react-native'
+import styled, { css } from 'styled-components/native'
+
+import PressableOpacity from './PressableOpacity'
+
+const Button = styled(PressableOpacity)<{ hasBorder: boolean; hasShadow: boolean }>`
+  width: ${props => props.theme.spacings.lg};
+  height: ${props => props.theme.spacings.lg};
+  border-radius: ${props => props.theme.spacings.sm};
+  align-items: center;
+  justify-content: center;
+  ${props =>
+    props.hasBorder &&
+    css`
+      border: 1px solid ${props.theme.colors.backgroundHigh};
+    `}
+  ${props =>
+    props.hasShadow &&
+    css`
+      shadow-color: ${props.theme.colors.shadow};
+      shadow-radius: 5px;
+      shadow-offset: 1px 1px;
+      shadow-opacity: 0.5;
+    `}
+`
+
+type CircularIconButtonProps = {
+  children: ReactNode
+  onPress: () => void
+  hasBorder?: boolean
+  hasShadow?: boolean
+  accessibilityLabel?: string
+  testID?: string
+  style?: StyleProp<ViewStyle>
+}
+
+const CircularIconButton = ({
+  children,
+  onPress,
+  hasBorder = false,
+  hasShadow = false,
+  accessibilityLabel,
+  testID,
+  style,
+}: CircularIconButtonProps): ReactElement => (
+  <Button
+    onPress={onPress}
+    hasBorder={hasBorder}
+    hasShadow={hasShadow}
+    accessibilityLabel={accessibilityLabel}
+    testID={testID}
+    style={style}
+  >
+    {children}
+  </Button>
+)
+
+export default CircularIconButton

--- a/src/components/CustomTextInput.tsx
+++ b/src/components/CustomTextInput.tsx
@@ -2,9 +2,11 @@ import React, { ReactElement, useState } from 'react'
 import { StyleProp, TextInputProps, ViewStyle } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
-import { CloseIcon } from '../../assets/images'
+import { CloseIcon, InfoCircleIcon } from '../../assets/images'
+import { getLabels } from '../services/helpers'
 import PressableOpacity from './PressableOpacity'
 import { ContentError } from './text/Content'
+import { HintSecondary } from './text/Hint'
 
 const LINE_HEIGHT = 32
 const MIN_HEIGHT = 56
@@ -36,10 +38,43 @@ const IconContainer = styled.View<{ multiLine: boolean }>`
   padding: ${props => props.theme.spacings.xs} 0;
 `
 
-const ErrorContainer = styled.View`
+const FooterContainer = styled.View`
+  flex-direction: row;
+  margin-top: ${props => props.theme.spacings.xs};
+`
+
+const ErrorRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: ${props => props.theme.spacings.xs};
   margin-top: ${props => props.theme.spacings.xs};
   min-height: ${props => props.theme.spacings.lg};
 `
+
+const ErrorText = styled(ContentError)`
+  flex: 1;
+`
+
+const HintText = styled(HintSecondary)`
+  flex: 1;
+`
+
+const CharacterCount = styled(HintSecondary)<{ isAtLimit: boolean }>`
+  margin-left: auto;
+  ${props => props.isAtLimit && `color: ${props.theme.colors.incorrect};`}
+`
+
+// Native maxLength counts UTF-16 code units, so the limit is enforced here to count an emoji once
+const countCharacters = (text: string): number => [...text].length
+
+const truncateToCharacterLimit = (text: string, limit: number): string => [...text].slice(0, limit).join('')
+
+const characterCountDescription = (text: string, limit: number): string =>
+  getLabels()
+    .general.characterCount.replace('{{count}}', countCharacters(text).toString())
+    .replace('{{limit}}', limit.toString())
+
+const characterCountText = (text: string, limit: number): string => `${countCharacters(text)} / ${limit}`
 
 type CustomTextInputProps = {
   value: string
@@ -50,6 +85,8 @@ type CustomTextInputProps = {
   errorMessage?: string
   customBorderColor?: string
   style?: StyleProp<ViewStyle>
+  characterLimit?: number
+  hint?: string
 } & TextInputProps
 
 const CustomTextInput = ({
@@ -65,18 +102,32 @@ const CustomTextInput = ({
   onSubmitEditing,
   customBorderColor,
   style,
+  characterLimit,
+  hint,
 }: CustomTextInputProps): ReactElement => {
   const theme = useTheme()
   const [isFocused, setIsFocused] = useState<boolean>(false)
   const showErrorValidation = errorMessage !== undefined
+  const hasCharacterLimit = characterLimit !== undefined
   const multiLine = lines > 1
+  const errorText = showErrorValidation && errorMessage.length > 0 ? errorMessage : undefined
+
+  const changeText = (text: string): void => {
+    if (!hasCharacterLimit) {
+      onChangeText(text)
+      return
+    }
+    onChangeText(truncateToCharacterLimit(text, characterLimit))
+  }
 
   const getBorderColor = (): string => {
-    if (showErrorValidation && errorMessage.length > 0) {
+    if (errorText !== undefined) {
       return theme.colors.incorrect
     }
     return isFocused ? theme.colors.primary : theme.colors.textSecondary
   }
+
+  const showFooter = hasCharacterLimit || hint !== undefined
 
   return (
     <>
@@ -91,7 +142,7 @@ const CustomTextInput = ({
           onBlur={() => setIsFocused(false)}
           textContentType={textContentType}
           value={value}
-          onChangeText={onChangeText}
+          onChangeText={changeText}
           placeholder={placeholder}
           multiline={multiLine}
           placeholderTextColor={theme.colors.placeholder}
@@ -101,7 +152,7 @@ const CustomTextInput = ({
         />
         <IconContainer multiLine={multiLine}>
           {clearable && value.length > 0 ? (
-            <ClearContainer onPress={() => onChangeText('')} testID='clearInput'>
+            <ClearContainer onPress={() => changeText('')} testID='clearInput'>
               <CloseIcon width={theme.spacingsPlain.md} height={theme.spacingsPlain.md} color={theme.colors.primary} />
             </ClearContainer>
           ) : (
@@ -109,8 +160,32 @@ const CustomTextInput = ({
           )}
         </IconContainer>
       </TextInputContainer>
+      {showFooter && (
+        <FooterContainer>
+          {hint !== undefined && <HintText>{hint}</HintText>}
+          {hasCharacterLimit && (
+            <CharacterCount
+              isAtLimit={countCharacters(value) >= characterLimit}
+              accessibilityLabel={characterCountDescription(value, characterLimit)}
+            >
+              {characterCountText(value, characterLimit)}
+            </CharacterCount>
+          )}
+        </FooterContainer>
+      )}
       {showErrorValidation && (
-        <ErrorContainer>{errorMessage.length > 0 && <ContentError>{errorMessage}</ContentError>}</ErrorContainer>
+        <ErrorRow>
+          {errorText !== undefined && (
+            <>
+              <InfoCircleIcon
+                width={theme.spacingsPlain.sm}
+                height={theme.spacingsPlain.sm}
+                color={theme.colors.incorrect}
+              />
+              <ErrorText>{errorText}</ErrorText>
+            </>
+          )}
+        </ErrorRow>
       )}
     </>
   )

--- a/src/components/CustomTextInput.tsx
+++ b/src/components/CustomTextInput.tsx
@@ -64,17 +64,13 @@ const CharacterCount = styled(HintSecondary)<{ isAtLimit: boolean }>`
   ${props => props.isAtLimit && `color: ${props.theme.colors.incorrect};`}
 `
 
-// Native maxLength counts UTF-16 code units, so the limit is enforced here to count an emoji once
-const countCharacters = (text: string): number => [...text].length
+// Enforced here rather than through native maxLength, which counts code units and so an emoji twice
+const countCodePoints = (text: string): number => [...text].length
 
-const truncateToCharacterLimit = (text: string, limit: number): string => [...text].slice(0, limit).join('')
+const truncateToCodePointLimit = (text: string, limit: number): string => [...text].slice(0, limit).join('')
 
-const characterCountDescription = (text: string, limit: number): string =>
-  getLabels()
-    .general.characterCount.replace('{{count}}', countCharacters(text).toString())
-    .replace('{{limit}}', limit.toString())
-
-const characterCountText = (text: string, limit: number): string => `${countCharacters(text)} / ${limit}`
+const characterCountDescription = (count: number, limit: number): string =>
+  getLabels().general.characterCount.replace('{{count}}', count.toString()).replace('{{limit}}', limit.toString())
 
 type CustomTextInputProps = {
   value: string
@@ -110,14 +106,16 @@ const CustomTextInput = ({
   const showErrorValidation = errorMessage !== undefined
   const hasCharacterLimit = characterLimit !== undefined
   const multiLine = lines > 1
+  const characterCount = hasCharacterLimit ? countCodePoints(value) : 0
   const errorText = showErrorValidation && errorMessage.length > 0 ? errorMessage : undefined
 
   const changeText = (text: string): void => {
-    if (!hasCharacterLimit) {
+    if (characterLimit === undefined) {
       onChangeText(text)
       return
     }
-    onChangeText(truncateToCharacterLimit(text, characterLimit))
+    const isWithinLimit = text.length <= characterLimit
+    onChangeText(isWithinLimit ? text : truncateToCodePointLimit(text, characterLimit))
   }
 
   const getBorderColor = (): string => {
@@ -165,10 +163,10 @@ const CustomTextInput = ({
           {hint !== undefined && <HintText>{hint}</HintText>}
           {hasCharacterLimit && (
             <CharacterCount
-              isAtLimit={countCharacters(value) >= characterLimit}
-              accessibilityLabel={characterCountDescription(value, characterLimit)}
+              isAtLimit={characterCount >= characterLimit}
+              accessibilityLabel={characterCountDescription(characterCount, characterLimit)}
             >
-              {characterCountText(value, characterLimit)}
+              {`${characterCount} / ${characterLimit}`}
             </CharacterCount>
           )}
         </FooterContainer>

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import { useTheme } from 'styled-components/native'
 
 import { StarCircleIconGrey, StarCircleIconGreyFilled } from '../../assets/images'
 import useRepetitionService from '../hooks/useRepetitionService'
@@ -7,19 +7,7 @@ import useStorage, { useStorageCache } from '../hooks/useStorage'
 import VocabularyItem from '../models/VocabularyItem'
 import { reportError } from '../services/sentry'
 import { addFavorite, isFavorite as getIsFavorite, removeFavorite } from '../services/storageUtils'
-import PressableOpacity from './PressableOpacity'
-
-const Button = styled(PressableOpacity)`
-  width: ${props => props.theme.spacings.lg};
-  height: ${props => props.theme.spacings.lg};
-  justify-content: center;
-  align-items: center;
-  shadow-color: ${props => props.theme.colors.shadow};
-  shadow-radius: 5px;
-  shadow-offset: 1px 1px;
-  shadow-opacity: 0.5;
-  border-radius: 20px;
-`
+import CircularIconButton from './CircularIconButton'
 
 type FavoriteButtonProps = {
   vocabularyItem: VocabularyItem
@@ -41,13 +29,13 @@ const FavoriteButton = ({ vocabularyItem }: FavoriteButtonProps): ReactElement |
   }
 
   return (
-    <Button testID={isFavorite ? 'remove' : 'add'} onPress={onPress}>
+    <CircularIconButton testID={isFavorite ? 'remove' : 'add'} onPress={onPress} hasShadow>
       {isFavorite ? (
         <StarCircleIconGreyFilled width={theme.spacingsPlain.lg} height={theme.spacingsPlain.lg} />
       ) : (
         <StarCircleIconGrey width={theme.spacingsPlain.lg} height={theme.spacingsPlain.lg} />
       )}
-    </Button>
+    </CircularIconButton>
   )
 }
 

--- a/src/components/ModalSkeleton.tsx
+++ b/src/components/ModalSkeleton.tsx
@@ -27,8 +27,12 @@ const IconRow = styled.View`
   align-items: flex-end;
 `
 
-const StyledPressable = styled(Pressable)`
-  flex: 1;
+const BackdropBehindContent = styled(Pressable)`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 `
 
 type ModalSkeletonProps = {
@@ -60,24 +64,23 @@ const ModalSkeleton = ({ visible, onClose, testID, children }: ModalSkeletonProp
       accessibilityViewIsModal
       supportedOrientations={['landscape', 'portrait']}
     >
-      <StyledPressable onPress={handleBackdropPress} accessible={Platform.OS !== 'ios'}>
-        <Overlay>
-          <ModalContainer bottomPosition={isKeyboardIosVisible ? keyboardHeight : undefined}>
-            <IconRow>
-              <Pressable onPress={onClose} accessibilityRole='button' accessibilityLabel={getLabels().general.close}>
-                <CloseIcon
-                  width={theme.spacingsPlain.md}
-                  height={theme.spacingsPlain.md}
-                  color={theme.colors.primary}
-                />
-              </Pressable>
-            </IconRow>
-            <ScrollView persistentScrollbar contentContainerStyle={{ alignItems: 'center' }}>
-              {children}
-            </ScrollView>
-          </ModalContainer>
-        </Overlay>
-      </StyledPressable>
+      <Overlay>
+        <BackdropBehindContent onPress={handleBackdropPress} accessible={false} />
+        <ModalContainer bottomPosition={isKeyboardIosVisible ? keyboardHeight : undefined}>
+          <IconRow>
+            <Pressable onPress={onClose} accessibilityRole='button' accessibilityLabel={getLabels().general.close}>
+              <CloseIcon width={theme.spacingsPlain.md} height={theme.spacingsPlain.md} color={theme.colors.primary} />
+            </Pressable>
+          </IconRow>
+          <ScrollView
+            persistentScrollbar
+            keyboardShouldPersistTaps='handled'
+            contentContainerStyle={{ alignItems: 'center' }}
+          >
+            {children}
+          </ScrollView>
+        </ModalContainer>
+      </Overlay>
     </RNModal>
   )
 }

--- a/src/components/NavigationTitle.ts
+++ b/src/components/NavigationTitle.ts
@@ -1,11 +1,12 @@
 import styled from 'styled-components/native'
 
+import { uppercase } from './text/uppercase'
+
 export const NavigationTitle = styled.Text`
   color: ${props => props.theme.colors.primary};
   font-family: ${props => props.theme.fonts.contentFontBold};
   font-size: ${props => props.theme.fonts.defaultFontSize};
-  letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
-  text-transform: uppercase;
+  ${uppercase};
   padding-left: ${props => props.theme.spacings.sm};
   padding-right: ${props => props.theme.spacings.xxs};
   flex: 1;

--- a/src/components/VocabularyDetail.tsx
+++ b/src/components/VocabularyDetail.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/native'
 
 import VocabularyItem from '../models/VocabularyItem'
 import VocabularyItemImageSection from './VocabularyItemImageSection'
+import VocabularyNoteSection from './VocabularyNoteSection'
 import WordItem from './WordItem'
 
 const ItemContainer = styled.View`
@@ -20,6 +21,7 @@ const VocabularyDetail = ({ vocabularyItem }: VocabularyDetailProps): ReactEleme
     <VocabularyItemImageSection vocabularyItem={vocabularyItem} />
     <ItemContainer>
       <WordItem answer={{ word: vocabularyItem.word, article: vocabularyItem.article }} isPrimaryContent />
+      <VocabularyNoteSection vocabularyItem={vocabularyItem} />
     </ItemContainer>
   </>
 )

--- a/src/components/VocabularyDetail.tsx
+++ b/src/components/VocabularyDetail.tsx
@@ -21,7 +21,7 @@ const VocabularyDetail = ({ vocabularyItem }: VocabularyDetailProps): ReactEleme
     <VocabularyItemImageSection vocabularyItem={vocabularyItem} />
     <ItemContainer>
       <WordItem answer={{ word: vocabularyItem.word, article: vocabularyItem.article }} isPrimaryContent />
-      <VocabularyNoteSection vocabularyItem={vocabularyItem} />
+      <VocabularyNoteSection wordId={vocabularyItem.id} />
     </ItemContainer>
   </>
 )

--- a/src/components/VocabularyNoteCard.tsx
+++ b/src/components/VocabularyNoteCard.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components/native'
+
+import PressableOpacity from './PressableOpacity'
+
+const VocabularyNoteCard = styled(PressableOpacity)`
+  flex-direction: column;
+  background-color: ${props => props.theme.colors.backgroundAccent};
+  border-radius: ${props => props.theme.spacings.xs};
+  padding: ${props => props.theme.spacings.sm};
+`
+
+export default VocabularyNoteCard

--- a/src/components/VocabularyNoteEditor.tsx
+++ b/src/components/VocabularyNoteEditor.tsx
@@ -1,0 +1,71 @@
+import React, { ReactElement, useState } from 'react'
+import styled from 'styled-components/native'
+
+import { useStorageCache } from '../hooks/useStorage'
+import { VocabularyItemId } from '../models/VocabularyItem'
+import { getLabels } from '../services/helpers'
+import { reportError } from '../services/sentry'
+import { saveVocabularyNote } from '../services/storageUtils'
+import CustomTextInput from './CustomTextInput'
+import Modal from './Modal'
+
+const MAX_NOTE_CHARACTERS = 500
+const NOTE_INPUT_LINES = 8
+
+const TextInputContainer = styled.View`
+  width: 85%;
+  margin-bottom: ${props => props.theme.spacings.lg};
+`
+
+type VocabularyNoteEditorProps = {
+  wordId: VocabularyItemId
+  existingText: string | null
+  onClose: () => void
+}
+
+const VocabularyNoteEditor = ({ wordId, existingText, onClose }: VocabularyNoteEditorProps): ReactElement => {
+  const storageCache = useStorageCache()
+  const [noteText, setNoteText] = useState<string>(existingText ?? '')
+  const [isValidationEnabled, setIsValidationEnabled] = useState<boolean>(existingText !== null)
+
+  const { newNote, edit, languageHint, placeholder, emptyError, cancel, save } = getLabels().notes
+  const isNoteBlank = noteText.trim().length === 0
+
+  const changeNoteText = (text: string): void => {
+    setNoteText(text)
+    setIsValidationEnabled(true)
+  }
+
+  const saveNote = (): void => {
+    saveVocabularyNote(storageCache, wordId, noteText).catch(reportError)
+    onClose()
+  }
+
+  return (
+    <Modal
+      testID='noteEditorModal'
+      visible
+      onClose={onClose}
+      text={existingText === null ? newNote : edit}
+      confirmationButtonText={save}
+      cancelButtonText={cancel}
+      confirmationAction={saveNote}
+      confirmationDisabled={isNoteBlank}
+    >
+      <TextInputContainer>
+        <CustomTextInput
+          value={noteText}
+          onChangeText={changeNoteText}
+          placeholder={placeholder}
+          lines={NOTE_INPUT_LINES}
+          characterLimit={MAX_NOTE_CHARACTERS}
+          hint={languageHint}
+          errorMessage={isValidationEnabled && isNoteBlank ? emptyError : ''}
+          clearable
+        />
+      </TextInputContainer>
+    </Modal>
+  )
+}
+
+export default VocabularyNoteEditor

--- a/src/components/VocabularyNotePreview.tsx
+++ b/src/components/VocabularyNotePreview.tsx
@@ -1,0 +1,67 @@
+import React, { ReactElement, useState } from 'react'
+import styled, { css } from 'styled-components/native'
+
+import useVocabularyNote from '../hooks/useVocabularyNote'
+import { VocabularyItemId } from '../models/VocabularyItem'
+import { getLabels } from '../services/helpers'
+import AddVocabularyNoteButton from './AddVocabularyNoteButton'
+import VocabularyNoteCard from './VocabularyNoteCard'
+import VocabularyNoteEditor from './VocabularyNoteEditor'
+import { ContentText } from './text/Content'
+import { Hint, HintSecondary } from './text/Hint'
+import { uppercase } from './text/uppercase'
+
+const MAX_PREVIEW_LINES = 3
+
+const PreviewCard = styled(VocabularyNoteCard)<{ hasBorder: boolean }>`
+  gap: ${props => props.theme.spacings.xxs};
+  ${props =>
+    props.hasBorder &&
+    css`
+      border: 1px solid ${props.theme.colors.backgroundHigh};
+    `}
+`
+
+const ShowMoreLabel = styled(Hint)`
+  color: ${props => props.theme.colors.primary};
+  font-family: ${props => props.theme.fonts.contentFontBold};
+`
+
+const Heading = styled(HintSecondary)`
+  ${uppercase};
+`
+
+type VocabularyNotePreviewProps = {
+  wordId: VocabularyItemId
+  // Needed when the note sits on a white background instead of a coloured result sheet
+  hasBorder?: boolean
+}
+
+const VocabularyNotePreview = ({ wordId, hasBorder = false }: VocabularyNotePreviewProps): ReactElement => {
+  const { note, isEditorOpen, openEditor, closeEditor } = useVocabularyNote(wordId)
+  const [isNoteTruncated, setIsNoteTruncated] = useState<boolean>(false)
+
+  const { heading, edit, showMore } = getLabels().notes
+
+  return (
+    <>
+      {note ? (
+        <PreviewCard onPress={openEditor} accessibilityLabel={edit} hasBorder={hasBorder}>
+          <Heading>{heading}</Heading>
+          <ContentText
+            numberOfLines={MAX_PREVIEW_LINES}
+            onTextLayout={event => setIsNoteTruncated(event.nativeEvent.lines.length >= MAX_PREVIEW_LINES)}
+          >
+            {note.text}
+          </ContentText>
+          {isNoteTruncated && <ShowMoreLabel>{showMore}</ShowMoreLabel>}
+        </PreviewCard>
+      ) : (
+        <AddVocabularyNoteButton onPress={openEditor} />
+      )}
+      {isEditorOpen && <VocabularyNoteEditor wordId={wordId} existingText={note?.text ?? null} onClose={closeEditor} />}
+    </>
+  )
+}
+
+export default VocabularyNotePreview

--- a/src/components/VocabularyNotePreview.tsx
+++ b/src/components/VocabularyNotePreview.tsx
@@ -41,12 +41,12 @@ const VocabularyNotePreview = ({ wordId, hasBorder = false }: VocabularyNotePrev
   const { note, isEditorOpen, openEditor, closeEditor } = useVocabularyNote(wordId)
   const [isNoteTruncated, setIsNoteTruncated] = useState<boolean>(false)
 
-  const { heading, edit, showMore } = getLabels().notes
+  const { heading, showMore } = getLabels().notes
 
   return (
     <>
       {note ? (
-        <PreviewCard onPress={openEditor} accessibilityLabel={edit} hasBorder={hasBorder}>
+        <PreviewCard onPress={openEditor} hasBorder={hasBorder}>
           <Heading>{heading}</Heading>
           <ContentText
             numberOfLines={MAX_PREVIEW_LINES}

--- a/src/components/VocabularyNoteSection.tsx
+++ b/src/components/VocabularyNoteSection.tsx
@@ -1,35 +1,23 @@
 import React, { ReactElement, useState } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { AddCircleIcon, PenIcon, TrashIcon } from '../../assets/images'
-import useStorage, { useStorageCache } from '../hooks/useStorage'
-import VocabularyItem from '../models/VocabularyItem'
+import { PenIcon, TrashIcon } from '../../assets/images'
+import { useStorageCache } from '../hooks/useStorage'
+import useVocabularyNote from '../hooks/useVocabularyNote'
+import { VocabularyItemId } from '../models/VocabularyItem'
 import { getLabels } from '../services/helpers'
 import { reportError } from '../services/sentry'
-import { deleteVocabularyNote, getVocabularyNote, saveVocabularyNote } from '../services/storageUtils'
+import { deleteVocabularyNote } from '../services/storageUtils'
+import AddVocabularyNoteButton from './AddVocabularyNoteButton'
 import CircularIconButton from './CircularIconButton'
-import CustomTextInput from './CustomTextInput'
 import Modal from './Modal'
-import PressableOpacity from './PressableOpacity'
+import VocabularyNoteCard from './VocabularyNoteCard'
+import VocabularyNoteEditor from './VocabularyNoteEditor'
 import { ContentSecondary, ContentText } from './text/Content'
-import { SubheadingText } from './text/Subheading'
-
-const MAX_NOTE_CHARACTERS = 500
-const NOTE_INPUT_LINES = 8
+import { uppercase } from './text/uppercase'
 
 const Root = styled.View`
   padding-top: ${props => props.theme.spacings.sm};
-`
-
-const AddNoteRow = styled(PressableOpacity)`
-  align-items: center;
-  gap: ${props => props.theme.spacings.xs};
-  padding: ${props => props.theme.spacings.sm} 0;
-`
-
-const AddNoteLabel = styled(SubheadingText)`
-  font-size: ${props => props.theme.fonts.largeFontSize};
-  color: ${props => props.theme.colors.primary};
 `
 
 const HeadingRow = styled.View`
@@ -40,20 +28,11 @@ const HeadingRow = styled.View`
 `
 
 const Heading = styled(ContentSecondary)`
-  letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
-  text-transform: uppercase;
+  ${uppercase};
 `
 
-const NoteCard = styled(PressableOpacity)`
-  background-color: ${props => props.theme.colors.backgroundAccent};
+const BorderedVocabularyNoteCard = styled(VocabularyNoteCard)`
   border: 1px solid ${props => props.theme.colors.backgroundHigh};
-  border-radius: ${props => props.theme.spacings.xs};
-  padding: ${props => props.theme.spacings.sm};
-`
-
-// The card is a row, so the note has to shrink to wrap instead of overflowing
-const NoteText = styled(ContentText)`
-  flex: 1;
 `
 
 const ActionContainer = styled.View`
@@ -70,84 +49,42 @@ const DeletionExplanation = styled(ContentSecondary)`
   text-align: center;
 `
 
-const TextInputContainer = styled.View`
-  width: 85%;
-  margin-bottom: ${props => props.theme.spacings.lg};
-`
-
-// Text and flag in one state, so that closing the editor cannot leave the flag behind and flash
-// the empty-note error while the modal fades out
-type NoteDraft = {
-  text: string
-  hasBeenEdited: boolean
-}
-
 type VocabularyNoteSectionProps = {
-  vocabularyItem: VocabularyItem
+  wordId: VocabularyItemId
 }
 
-const VocabularyNoteSection = ({ vocabularyItem }: VocabularyNoteSectionProps): ReactElement => {
+const VocabularyNoteSection = ({ wordId }: VocabularyNoteSectionProps): ReactElement => {
   const theme = useTheme()
   const storageCache = useStorageCache()
-  const [vocabularyNotes] = useStorage('vocabularyNotes')
-  const [noteDraft, setNoteDraft] = useState<NoteDraft | null>(null)
+  const { note, isEditorOpen, openEditor, closeEditor } = useVocabularyNote(wordId)
   const [isDeletionConfirmationVisible, setIsDeletionConfirmationVisible] = useState<boolean>(false)
 
   const {
-    sectionTitle,
-    newNote,
-    add,
+    heading,
     edit,
     delete: deleteLabel,
-    languageHint,
-    placeholder,
-    emptyError,
-    confirmDeletionTitle,
+    deletionTitle,
+    deletionWarning,
     confirmDeletion,
-    confirm,
     cancel,
-    save,
   } = getLabels().notes
 
-  const note = getVocabularyNote(vocabularyNotes, vocabularyItem.id)
-  const isEditorVisible = noteDraft !== null
-  const noteDraftText = noteDraft?.text ?? ''
-  const isNoteDraftBlank = noteDraftText.trim().length === 0
-  const shouldShowEmptyError = (noteDraft?.hasBeenEdited ?? false) && isNoteDraftBlank
-
-  const openEditor = (initialText: string): void =>
-    setNoteDraft({ text: initialText, hasBeenEdited: initialText.length > 0 })
-
-  const changeNoteDraft = (text: string): void => setNoteDraft({ text, hasBeenEdited: true })
-
-  const closeEditor = (): void => setNoteDraft(null)
-
-  const submitNote = (): void => {
-    saveVocabularyNote(storageCache, vocabularyItem.id, noteDraftText).catch(reportError)
-    closeEditor()
-  }
-
   const deleteNote = (): void => {
-    deleteVocabularyNote(storageCache, vocabularyItem.id).catch(reportError)
+    deleteVocabularyNote(storageCache, wordId).catch(reportError)
     setIsDeletionConfirmationVisible(false)
   }
 
   const noteContent = (): ReactElement => {
     if (note === undefined) {
-      return (
-        <AddNoteRow onPress={() => openEditor('')} accessibilityLabel={add}>
-          <AddCircleIcon width={theme.spacingsPlain.md} height={theme.spacingsPlain.md} color={theme.colors.primary} />
-          <AddNoteLabel>{add}</AddNoteLabel>
-        </AddNoteRow>
-      )
+      return <AddVocabularyNoteButton onPress={openEditor} />
     }
 
     return (
       <>
         <HeadingRow>
-          <Heading>{sectionTitle}</Heading>
+          <Heading>{heading}</Heading>
           <ActionContainer>
-            <NoteIconButton onPress={() => openEditor(note.text)} accessibilityLabel={edit} hasBorder>
+            <NoteIconButton onPress={openEditor} accessibilityLabel={edit} hasBorder>
               <PenIcon testID='edit-note-icon' color={theme.colors.text} />
             </NoteIconButton>
             <NoteIconButton
@@ -159,9 +96,9 @@ const VocabularyNoteSection = ({ vocabularyItem }: VocabularyNoteSectionProps): 
             </NoteIconButton>
           </ActionContainer>
         </HeadingRow>
-        <NoteCard onPress={() => openEditor(note.text)}>
-          <NoteText>{note.text}</NoteText>
-        </NoteCard>
+        <BorderedVocabularyNoteCard onPress={openEditor}>
+          <ContentText>{note.text}</ContentText>
+        </BorderedVocabularyNoteCard>
       </>
     )
   }
@@ -169,38 +106,16 @@ const VocabularyNoteSection = ({ vocabularyItem }: VocabularyNoteSectionProps): 
   return (
     <>
       <Root>{noteContent()}</Root>
-      <Modal
-        testID='noteEditorModal'
-        visible={isEditorVisible}
-        onClose={closeEditor}
-        text={note ? edit : newNote}
-        confirmationButtonText={save}
-        cancelButtonText={cancel}
-        confirmationAction={submitNote}
-        confirmationDisabled={isNoteDraftBlank}
-      >
-        <TextInputContainer>
-          <CustomTextInput
-            value={noteDraftText}
-            onChangeText={changeNoteDraft}
-            placeholder={placeholder}
-            lines={NOTE_INPUT_LINES}
-            characterLimit={MAX_NOTE_CHARACTERS}
-            hint={languageHint}
-            errorMessage={shouldShowEmptyError ? emptyError : ''}
-            clearable
-          />
-        </TextInputContainer>
-      </Modal>
+      {isEditorOpen && <VocabularyNoteEditor wordId={wordId} existingText={note?.text ?? null} onClose={closeEditor} />}
       <Modal
         visible={isDeletionConfirmationVisible}
         onClose={() => setIsDeletionConfirmationVisible(false)}
-        text={confirmDeletionTitle}
-        confirmationButtonText={confirm}
+        text={deletionTitle}
+        confirmationButtonText={confirmDeletion}
         cancelButtonText={cancel}
         confirmationAction={deleteNote}
       >
-        <DeletionExplanation>{confirmDeletion}</DeletionExplanation>
+        <DeletionExplanation>{deletionWarning}</DeletionExplanation>
       </Modal>
     </>
   )

--- a/src/components/VocabularyNoteSection.tsx
+++ b/src/components/VocabularyNoteSection.tsx
@@ -1,0 +1,209 @@
+import React, { ReactElement, useState } from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { AddCircleIcon, PenIcon, TrashIcon } from '../../assets/images'
+import useStorage, { useStorageCache } from '../hooks/useStorage'
+import VocabularyItem from '../models/VocabularyItem'
+import { getLabels } from '../services/helpers'
+import { reportError } from '../services/sentry'
+import { deleteVocabularyNote, getVocabularyNote, saveVocabularyNote } from '../services/storageUtils'
+import CircularIconButton from './CircularIconButton'
+import CustomTextInput from './CustomTextInput'
+import Modal from './Modal'
+import PressableOpacity from './PressableOpacity'
+import { ContentSecondary, ContentText } from './text/Content'
+import { SubheadingText } from './text/Subheading'
+
+const MAX_NOTE_CHARACTERS = 500
+const NOTE_INPUT_LINES = 8
+
+const Root = styled.View`
+  padding-top: ${props => props.theme.spacings.sm};
+`
+
+const AddNoteRow = styled(PressableOpacity)`
+  align-items: center;
+  gap: ${props => props.theme.spacings.xs};
+  padding: ${props => props.theme.spacings.sm} 0;
+`
+
+const AddNoteLabel = styled(SubheadingText)`
+  font-size: ${props => props.theme.fonts.largeFontSize};
+  color: ${props => props.theme.colors.primary};
+`
+
+const HeadingRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: ${props => props.theme.spacings.xs};
+`
+
+const Heading = styled(ContentSecondary)`
+  letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
+  text-transform: uppercase;
+`
+
+const NoteCard = styled(PressableOpacity)`
+  background-color: ${props => props.theme.colors.backgroundAccent};
+  border: 1px solid ${props => props.theme.colors.backgroundHigh};
+  border-radius: ${props => props.theme.spacings.xs};
+  padding: ${props => props.theme.spacings.sm};
+`
+
+// The card is a row, so the note has to shrink to wrap instead of overflowing
+const NoteText = styled(ContentText)`
+  flex: 1;
+`
+
+const ActionContainer = styled.View`
+  flex-direction: row;
+  gap: ${props => props.theme.spacings.xs};
+`
+
+const NoteIconButton = styled(CircularIconButton)`
+  background-color: ${props => props.theme.colors.backgroundAccent};
+`
+
+const DeletionExplanation = styled(ContentSecondary)`
+  padding: 0 ${props => props.theme.spacings.sm} ${props => props.theme.spacings.md};
+  text-align: center;
+`
+
+const TextInputContainer = styled.View`
+  width: 85%;
+  margin-bottom: ${props => props.theme.spacings.lg};
+`
+
+// Text and flag in one state, so that closing the editor cannot leave the flag behind and flash
+// the empty-note error while the modal fades out
+type NoteDraft = {
+  text: string
+  hasBeenEdited: boolean
+}
+
+type VocabularyNoteSectionProps = {
+  vocabularyItem: VocabularyItem
+}
+
+const VocabularyNoteSection = ({ vocabularyItem }: VocabularyNoteSectionProps): ReactElement => {
+  const theme = useTheme()
+  const storageCache = useStorageCache()
+  const [vocabularyNotes] = useStorage('vocabularyNotes')
+  const [noteDraft, setNoteDraft] = useState<NoteDraft | null>(null)
+  const [isDeletionConfirmationVisible, setIsDeletionConfirmationVisible] = useState<boolean>(false)
+
+  const {
+    sectionTitle,
+    newNote,
+    add,
+    edit,
+    delete: deleteLabel,
+    languageHint,
+    placeholder,
+    emptyError,
+    confirmDeletionTitle,
+    confirmDeletion,
+    confirm,
+    cancel,
+    save,
+  } = getLabels().notes
+
+  const note = getVocabularyNote(vocabularyNotes, vocabularyItem.id)
+  const isEditorVisible = noteDraft !== null
+  const noteDraftText = noteDraft?.text ?? ''
+  const isNoteDraftBlank = noteDraftText.trim().length === 0
+  const shouldShowEmptyError = (noteDraft?.hasBeenEdited ?? false) && isNoteDraftBlank
+
+  const openEditor = (initialText: string): void =>
+    setNoteDraft({ text: initialText, hasBeenEdited: initialText.length > 0 })
+
+  const changeNoteDraft = (text: string): void => setNoteDraft({ text, hasBeenEdited: true })
+
+  const closeEditor = (): void => setNoteDraft(null)
+
+  const submitNote = (): void => {
+    saveVocabularyNote(storageCache, vocabularyItem.id, noteDraftText).catch(reportError)
+    closeEditor()
+  }
+
+  const deleteNote = (): void => {
+    deleteVocabularyNote(storageCache, vocabularyItem.id).catch(reportError)
+    setIsDeletionConfirmationVisible(false)
+  }
+
+  const noteContent = (): ReactElement => {
+    if (note === undefined) {
+      return (
+        <AddNoteRow onPress={() => openEditor('')} accessibilityLabel={add}>
+          <AddCircleIcon width={theme.spacingsPlain.md} height={theme.spacingsPlain.md} color={theme.colors.primary} />
+          <AddNoteLabel>{add}</AddNoteLabel>
+        </AddNoteRow>
+      )
+    }
+
+    return (
+      <>
+        <HeadingRow>
+          <Heading>{sectionTitle}</Heading>
+          <ActionContainer>
+            <NoteIconButton onPress={() => openEditor(note.text)} accessibilityLabel={edit} hasBorder>
+              <PenIcon testID='edit-note-icon' color={theme.colors.text} />
+            </NoteIconButton>
+            <NoteIconButton
+              onPress={() => setIsDeletionConfirmationVisible(true)}
+              accessibilityLabel={deleteLabel}
+              hasBorder
+            >
+              <TrashIcon testID='delete-note-icon' color={theme.colors.incorrect} />
+            </NoteIconButton>
+          </ActionContainer>
+        </HeadingRow>
+        <NoteCard onPress={() => openEditor(note.text)}>
+          <NoteText>{note.text}</NoteText>
+        </NoteCard>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Root>{noteContent()}</Root>
+      <Modal
+        testID='noteEditorModal'
+        visible={isEditorVisible}
+        onClose={closeEditor}
+        text={note ? edit : newNote}
+        confirmationButtonText={save}
+        cancelButtonText={cancel}
+        confirmationAction={submitNote}
+        confirmationDisabled={isNoteDraftBlank}
+      >
+        <TextInputContainer>
+          <CustomTextInput
+            value={noteDraftText}
+            onChangeText={changeNoteDraft}
+            placeholder={placeholder}
+            lines={NOTE_INPUT_LINES}
+            characterLimit={MAX_NOTE_CHARACTERS}
+            hint={languageHint}
+            errorMessage={shouldShowEmptyError ? emptyError : ''}
+            clearable
+          />
+        </TextInputContainer>
+      </Modal>
+      <Modal
+        visible={isDeletionConfirmationVisible}
+        onClose={() => setIsDeletionConfirmationVisible(false)}
+        text={confirmDeletionTitle}
+        confirmationButtonText={confirm}
+        cancelButtonText={cancel}
+        confirmationAction={deleteNote}
+      >
+        <DeletionExplanation>{confirmDeletion}</DeletionExplanation>
+      </Modal>
+    </>
+  )
+}
+
+export default VocabularyNoteSection

--- a/src/components/WordResultIndicator.tsx
+++ b/src/components/WordResultIndicator.tsx
@@ -1,9 +1,11 @@
 import React, { ReactElement } from 'react'
-import styled from 'styled-components/native'
+import styled, { css } from 'styled-components/native'
 
 import { ThumbsDownIcon, ThumbsUpIcon } from '../../assets/images'
 import theme from '../constants/theme'
+import { VocabularyItemId } from '../models/VocabularyItem'
 import BottomSheet from './BottomSheet'
+import VocabularyNotePreview from './VocabularyNotePreview'
 import { HeadingText } from './text/Heading'
 import { Hint } from './text/Hint'
 
@@ -20,12 +22,20 @@ const BottomSheetRow = styled.View`
   gap: ${props => props.theme.spacings.sm};
 `
 
+const sheetContentInset = css`
+  align-self: stretch;
+  margin: 0 ${props => props.theme.spacings.xs};
+`
+
 const BottomSheetWordContainer = styled.View`
+  ${sheetContentInset};
   background-color: ${props => props.theme.colors.background};
   padding: ${props => props.theme.spacings.xs};
   border-radius: ${props => props.theme.spacings.xxs};
-  align-self: stretch;
-  margin: 0 ${props => props.theme.spacings.md};
+`
+
+const NoteContainer = styled.View`
+  ${sheetContentInset};
 `
 
 const FeedbackText = styled(Hint)`
@@ -38,6 +48,7 @@ type WordResultIndicatorProps = {
   isCorrect: boolean
   label: string
   content: ReactElement | null
+  wordId: VocabularyItemId
   button: ReactElement
   hint?: string
 }
@@ -46,6 +57,7 @@ const WordResultIndicator = ({
   isCorrect,
   label,
   content,
+  wordId,
   button,
   hint,
 }: WordResultIndicatorProps): ReactElement => {
@@ -61,6 +73,10 @@ const WordResultIndicator = ({
         </BottomSheetRow>
 
         {content && <BottomSheetWordContainer>{content}</BottomSheetWordContainer>}
+
+        <NoteContainer>
+          <VocabularyNotePreview wordId={wordId} />
+        </NoteContainer>
 
         {hint !== undefined && <FeedbackText>{hint}</FeedbackText>}
 

--- a/src/components/__tests__/CustomTextInput.spec.tsx
+++ b/src/components/__tests__/CustomTextInput.spec.tsx
@@ -1,5 +1,7 @@
+import { fireEvent } from '@testing-library/react-native'
 import React from 'react'
 
+import { COLORS } from '../../constants/theme/colors'
 import render from '../../testing/render'
 import CustomTextInput from '../CustomTextInput'
 
@@ -25,5 +27,95 @@ describe('CustomTextInput', () => {
       <CustomTextInput value='My Input' clearable placeholder='Test' onChangeText={onChangeText} />,
     )
     expect(getByTestId('clearInput')).toBeTruthy()
+  })
+
+  describe('characterLimit', () => {
+    it('should not show a counter without a limit', () => {
+      const { queryByText } = render(<CustomTextInput value='abc' placeholder='Test' onChangeText={onChangeText} />)
+      expect(queryByText('3 / 10')).toBeNull()
+    })
+
+    it('should count code points so that an emoji counts as one character', () => {
+      const { getByText } = render(
+        <CustomTextInput value='🚧🧱🔧' characterLimit={10} placeholder='Test' onChangeText={onChangeText} />,
+      )
+      expect(getByText('3 / 10')).toBeTruthy()
+    })
+
+    it('should truncate input to the limit', () => {
+      const { getByPlaceholderText } = render(
+        <CustomTextInput value='' characterLimit={5} placeholder='Test' onChangeText={onChangeText} />,
+      )
+
+      fireEvent.changeText(getByPlaceholderText('Test'), 'abcdefgh')
+
+      expect(onChangeText).toHaveBeenCalledWith('abcde')
+    })
+
+    it('should truncate a pasted insertion instead of rejecting it', () => {
+      const { getByPlaceholderText } = render(
+        <CustomTextInput value='abcd' characterLimit={5} placeholder='Test' onChangeText={onChangeText} />,
+      )
+
+      fireEvent.changeText(getByPlaceholderText('Test'), 'aXYbcd')
+
+      expect(onChangeText).toHaveBeenCalledWith('aXYbc')
+    })
+
+    it('should mark the counter as at the limit', () => {
+      const { getByText } = render(
+        <CustomTextInput value={'a'.repeat(5)} characterLimit={5} placeholder='Test' onChangeText={onChangeText} />,
+      )
+
+      expect(getByText('5 / 5')).toHaveStyle({ color: COLORS.incorrect })
+    })
+
+    it('should not mark the counter below the limit', () => {
+      const { getByText } = render(
+        <CustomTextInput value='abcd' characterLimit={5} placeholder='Test' onChangeText={onChangeText} />,
+      )
+
+      expect(getByText('4 / 5')).not.toHaveStyle({ color: COLORS.incorrect })
+    })
+
+    it('should still truncate text appended to what is already there', () => {
+      const { getByPlaceholderText } = render(
+        <CustomTextInput value='ab' characterLimit={5} placeholder='Test' onChangeText={onChangeText} />,
+      )
+
+      fireEvent.changeText(getByPlaceholderText('Test'), 'abcdefgh')
+
+      expect(onChangeText).toHaveBeenCalledWith('abcde')
+    })
+
+    it('should show the error message without hiding the hint', () => {
+      const { getByText, rerender } = render(
+        <CustomTextInput value='abc' hint='Any language' placeholder='Test' onChangeText={onChangeText} />,
+      )
+      expect(getByText('Any language')).toBeTruthy()
+
+      rerender(
+        <CustomTextInput
+          value=''
+          hint='Any language'
+          errorMessage='Cannot be empty'
+          placeholder='Test'
+          onChangeText={onChangeText}
+        />,
+      )
+
+      expect(getByText('Cannot be empty')).toBeTruthy()
+      expect(getByText('Any language')).toBeTruthy()
+    })
+
+    it('should not truncate input that is within the limit', () => {
+      const { getByPlaceholderText } = render(
+        <CustomTextInput value='' characterLimit={5} placeholder='Test' onChangeText={onChangeText} />,
+      )
+
+      fireEvent.changeText(getByPlaceholderText('Test'), 'abc')
+
+      expect(onChangeText).toHaveBeenCalledWith('abc')
+    })
   })
 })

--- a/src/components/__tests__/Modal.spec.tsx
+++ b/src/components/__tests__/Modal.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
 
+import useKeyboard from '../../hooks/useKeyboard'
 import render from '../../testing/render'
 import Modal, { ModalProps } from '../Modal'
 
@@ -44,5 +45,15 @@ describe('Modal', () => {
   it('should check for children if available', () => {
     const { getByText } = render(<Modal {...defaultProps} />)
     expect(getByText(childText)).toBeTruthy()
+  })
+
+  it('should trigger action on confirm while the keyboard is open', () => {
+    jest.mocked(useKeyboard).mockReturnValueOnce({ isKeyboardVisible: true, keyboardHeight: 300 })
+    const { getByText } = render(<Modal {...defaultProps} />)
+
+    fireEvent.press(getByText('confirm'))
+
+    expect(confirmationAction).toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/src/components/__tests__/VocabularyNoteEditor.spec.tsx
+++ b/src/components/__tests__/VocabularyNoteEditor.spec.tsx
@@ -1,0 +1,103 @@
+import { act, fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { StorageCache } from '../../services/Storage'
+import { getLabels } from '../../services/helpers'
+import VocabularyItemBuilder from '../../testing/VocabularyItemBuilder'
+import { renderWithStorageCache } from '../../testing/render'
+import VocabularyNoteEditor from '../VocabularyNoteEditor'
+
+describe('VocabularyNoteEditor', () => {
+  const wordId = new VocabularyItemBuilder(1).build()[0]!.id
+  const { newNote, edit, placeholder, emptyError, save } = getLabels().notes
+
+  let storageCache: StorageCache
+
+  beforeEach(() => {
+    storageCache = StorageCache.createDummy()
+  })
+
+  const renderEditor = (existingText: string | null) =>
+    renderWithStorageCache(
+      storageCache,
+      <VocabularyNoteEditor wordId={wordId} existingText={existingText} onClose={() => undefined} />,
+    )
+
+  describe('for a new note', () => {
+    it('should be titled as a new note and start empty', () => {
+      const { getByText, getByPlaceholderText } = renderEditor(null)
+
+      expect(getByText(newNote)).toBeDefined()
+      expect(getByPlaceholderText(placeholder).props.value).toBe('')
+    })
+
+    it('should save what was typed', async () => {
+      const { getByText, getByPlaceholderText } = renderEditor(null)
+
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'Wie das englische Wort'))
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([{ wordId, text: 'Wie das englische Wort' }])
+    })
+
+    it('should not save a note that only contains whitespace', async () => {
+      const { getByText, getByPlaceholderText } = renderEditor(null)
+
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), '   '))
+      expect(getByText(emptyError)).toBeDefined()
+
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
+    })
+
+    it('should not show an error before the user has typed', () => {
+      const { queryByText } = renderEditor(null)
+
+      expect(queryByText(emptyError)).toBeNull()
+    })
+
+    it('should count an emoji as a single character', async () => {
+      const { getByText, getByPlaceholderText } = renderEditor(null)
+
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), '🚧🧱🔧'))
+
+      expect(getByText('3 / 500')).toBeDefined()
+    })
+
+    it('should not accept more than 500 characters', async () => {
+      const { getByText, getByPlaceholderText } = renderEditor(null)
+
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'a'.repeat(600)))
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')[0]!.text).toHaveLength(500)
+    })
+  })
+
+  describe('for an existing note', () => {
+    it('should be titled as editing and start pre-filled', () => {
+      const { getByText, getByPlaceholderText } = renderEditor('Auf der Baustelle gelernt')
+
+      expect(getByText(edit)).toBeDefined()
+      expect(getByPlaceholderText(placeholder).props.value).toBe('Auf der Baustelle gelernt')
+    })
+
+    it('should replace the note when it is changed', async () => {
+      const { getByText, getByPlaceholderText } = renderEditor('Auf der Baustelle gelernt')
+
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'Im Praktikum gelernt'))
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([{ wordId, text: 'Im Praktikum gelernt' }])
+    })
+
+    it('should explain why saving is blocked when the note is cleared', async () => {
+      const { getByText, getByPlaceholderText } = renderEditor('Auf der Baustelle gelernt')
+
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), ''))
+
+      expect(getByText(emptyError)).toBeDefined()
+    })
+  })
+})

--- a/src/components/__tests__/VocabularyNotePreview.spec.tsx
+++ b/src/components/__tests__/VocabularyNotePreview.spec.tsx
@@ -1,0 +1,74 @@
+import { act, fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { StorageCache } from '../../services/Storage'
+import { getLabels } from '../../services/helpers'
+import { saveVocabularyNote } from '../../services/storageUtils'
+import VocabularyItemBuilder from '../../testing/VocabularyItemBuilder'
+import { renderWithStorageCache } from '../../testing/render'
+import VocabularyNotePreview from '../VocabularyNotePreview'
+
+describe('VocabularyNotePreview', () => {
+  const wordId = new VocabularyItemBuilder(1).build()[0]!.id
+  const { add, edit, heading, showMore, placeholder } = getLabels().notes
+  const noteText = 'Auf der Baustelle gelernt'
+
+  let storageCache: StorageCache
+
+  beforeEach(() => {
+    storageCache = StorageCache.createDummy()
+  })
+
+  const renderResult = () => renderWithStorageCache(storageCache, <VocabularyNotePreview wordId={wordId} />)
+
+  describe('when no note exists', () => {
+    it('should offer to add one without showing the section', () => {
+      const { getByText, queryByText } = renderResult()
+
+      expect(getByText(add)).toBeDefined()
+      expect(queryByText(heading)).toBeNull()
+    })
+
+    it('should open the editor for a new note', async () => {
+      const result = renderResult()
+
+      await act(async () => fireEvent.press(result.getByText(add)))
+
+      expect(result.getByPlaceholderText(placeholder).props.value).toBe('')
+    })
+  })
+
+  describe('when a note exists', () => {
+    beforeEach(async () => {
+      await saveVocabularyNote(storageCache, wordId, noteText)
+    })
+
+    it('should show the note under its heading', () => {
+      const { getByText } = renderResult()
+
+      expect(getByText(heading)).toBeDefined()
+      expect(getByText(noteText)).toBeDefined()
+    })
+
+    it('should offer to show more only when the note does not fit', () => {
+      const { getByText, queryByText } = renderResult()
+      const layOutInLines = (count: number) =>
+        fireEvent(getByText(noteText), 'textLayout', { nativeEvent: { lines: Array(count).fill({}) } })
+
+      act(() => layOutInLines(2))
+      expect(queryByText(showMore)).toBeNull()
+
+      act(() => layOutInLines(3))
+
+      expect(getByText(showMore)).toBeDefined()
+    })
+
+    it('should open the editor pre-filled when tapped', async () => {
+      const result = renderResult()
+
+      await act(async () => fireEvent.press(result.getByLabelText(edit)))
+
+      expect(result.getByPlaceholderText(placeholder).props.value).toBe(noteText)
+    })
+  })
+})

--- a/src/components/__tests__/VocabularyNotePreview.spec.tsx
+++ b/src/components/__tests__/VocabularyNotePreview.spec.tsx
@@ -10,7 +10,7 @@ import VocabularyNotePreview from '../VocabularyNotePreview'
 
 describe('VocabularyNotePreview', () => {
   const wordId = new VocabularyItemBuilder(1).build()[0]!.id
-  const { add, edit, heading, showMore, placeholder } = getLabels().notes
+  const { add, heading, showMore, placeholder } = getLabels().notes
   const noteText = 'Auf der Baustelle gelernt'
 
   let storageCache: StorageCache
@@ -66,7 +66,7 @@ describe('VocabularyNotePreview', () => {
     it('should open the editor pre-filled when tapped', async () => {
       const result = renderResult()
 
-      await act(async () => fireEvent.press(result.getByLabelText(edit)))
+      await act(async () => fireEvent.press(result.getByText(noteText)))
 
       expect(result.getByPlaceholderText(placeholder).props.value).toBe(noteText)
     })

--- a/src/components/__tests__/VocabularyNoteSection.spec.tsx
+++ b/src/components/__tests__/VocabularyNoteSection.spec.tsx
@@ -9,8 +9,9 @@ import { renderWithStorageCache } from '../../testing/render'
 import VocabularyNoteSection from '../VocabularyNoteSection'
 
 describe('VocabularyNoteSection', () => {
-  const vocabularyItem = new VocabularyItemBuilder(1).build()[0]!
-  const { add, edit, delete: deleteLabel, placeholder, emptyError, confirm, save } = getLabels().notes
+  const wordId = new VocabularyItemBuilder(1).build()[0]!.id
+  const { add, edit, delete: deleteLabel, placeholder, confirmDeletion } = getLabels().notes
+  const noteText = 'Auf der Baustelle gelernt'
 
   let storageCache: StorageCache
 
@@ -18,8 +19,7 @@ describe('VocabularyNoteSection', () => {
     storageCache = StorageCache.createDummy()
   })
 
-  const renderSection = () =>
-    renderWithStorageCache(storageCache, <VocabularyNoteSection vocabularyItem={vocabularyItem} />)
+  const renderSection = () => renderWithStorageCache(storageCache, <VocabularyNoteSection wordId={wordId} />)
 
   describe('when no note exists', () => {
     it('should offer to add one', () => {
@@ -28,114 +28,41 @@ describe('VocabularyNoteSection', () => {
       expect(getByText(add)).toBeDefined()
     })
 
-    it('should save a typed note', async () => {
+    it('should open the editor for a new note', async () => {
       const { getByText, getByPlaceholderText } = renderSection()
 
       await act(async () => fireEvent.press(getByText(add)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'Wie das englische Wort'))
-      await act(async () => fireEvent.press(getByText(save)))
 
-      expect(storageCache.getItem('vocabularyNotes')).toEqual([
-        { wordId: vocabularyItem.id, text: 'Wie das englische Wort' },
-      ])
-    })
-
-    it('should not save a note that only contains whitespace', async () => {
-      const { getByText, getByPlaceholderText } = renderSection()
-
-      await act(async () => fireEvent.press(getByText(add)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), '   '))
-      expect(getByText(emptyError)).toBeDefined()
-
-      await act(async () => fireEvent.press(getByText(save)))
-
-      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
-    })
-
-    it('should explain why saving is blocked after clearing what was typed', async () => {
-      const { getByText, getByPlaceholderText } = renderSection()
-
-      await act(async () => fireEvent.press(getByText(add)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'ab'))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), ''))
-
-      expect(getByText(emptyError)).toBeDefined()
-    })
-
-    it('should not show an error before the user has typed', async () => {
-      const { getByText, queryByText } = renderSection()
-
-      await act(async () => fireEvent.press(getByText(add)))
-
-      expect(queryByText(emptyError)).toBeNull()
-    })
-
-    it('should count an emoji as a single character', async () => {
-      const { getByText, getByPlaceholderText } = renderSection()
-
-      await act(async () => fireEvent.press(getByText(add)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), '🚧🧱🔧'))
-
-      expect(getByText('3 / 500')).toBeDefined()
-    })
-
-    it('should not accept more than 500 characters', async () => {
-      const { getByText, getByPlaceholderText } = renderSection()
-
-      await act(async () => fireEvent.press(getByText(add)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'a'.repeat(600)))
-      await act(async () => fireEvent.press(getByText(save)))
-
-      expect(storageCache.getItem('vocabularyNotes')[0]!.text).toHaveLength(500)
+      expect(getByPlaceholderText(placeholder).props.value).toBe('')
     })
   })
 
   describe('when a note exists', () => {
     beforeEach(async () => {
-      await saveVocabularyNote(storageCache, vocabularyItem.id, 'Auf der Baustelle gelernt')
+      await saveVocabularyNote(storageCache, wordId, noteText)
     })
 
-    it('should show the note', () => {
-      const { getByText } = renderSection()
+    it('should show the note without offering to add one', () => {
+      const { getByText, queryByText } = renderSection()
 
-      expect(getByText('Auf der Baustelle gelernt')).toBeDefined()
+      expect(getByText(noteText)).toBeDefined()
+      expect(queryByText(add)).toBeNull()
     })
 
     it('should open the editor when the note itself is tapped', async () => {
       const { getByText, getByPlaceholderText } = renderSection()
 
-      await act(async () => fireEvent.press(getByText('Auf der Baustelle gelernt')))
+      await act(async () => fireEvent.press(getByText(noteText)))
 
-      expect(getByPlaceholderText(placeholder).props.value).toBe('Auf der Baustelle gelernt')
+      expect(getByPlaceholderText(placeholder).props.value).toBe(noteText)
     })
 
-    it('should open the editor pre-filled with the existing note', async () => {
+    it('should open the editor from the edit button', async () => {
       const { getByLabelText, getByPlaceholderText } = renderSection()
 
       await act(async () => fireEvent.press(getByLabelText(edit)))
 
-      expect(getByPlaceholderText(placeholder).props.value).toBe('Auf der Baustelle gelernt')
-    })
-
-    it('should replace the note when it is edited', async () => {
-      const { getByLabelText, getByText, getByPlaceholderText } = renderSection()
-
-      await act(async () => fireEvent.press(getByLabelText(edit)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'Im Praktikum gelernt'))
-      await act(async () => fireEvent.press(getByText(save)))
-
-      expect(storageCache.getItem('vocabularyNotes')).toEqual([
-        { wordId: vocabularyItem.id, text: 'Im Praktikum gelernt' },
-      ])
-    })
-
-    it('should explain why saving is blocked when the note is cleared', async () => {
-      const { getByLabelText, getByText, getByPlaceholderText } = renderSection()
-
-      await act(async () => fireEvent.press(getByLabelText(edit)))
-      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), ''))
-
-      expect(getByText(emptyError)).toBeDefined()
+      expect(getByPlaceholderText(placeholder).props.value).toBe(noteText)
     })
 
     it('should keep the note until the deletion is confirmed', async () => {
@@ -144,7 +71,7 @@ describe('VocabularyNoteSection', () => {
       await act(async () => fireEvent.press(getByLabelText(deleteLabel)))
       expect(storageCache.getItem('vocabularyNotes')).toHaveLength(1)
 
-      await act(async () => fireEvent.press(getByText(confirm)))
+      await act(async () => fireEvent.press(getByText(confirmDeletion)))
 
       expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
     })

--- a/src/components/__tests__/VocabularyNoteSection.spec.tsx
+++ b/src/components/__tests__/VocabularyNoteSection.spec.tsx
@@ -1,0 +1,152 @@
+import { act, fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { StorageCache } from '../../services/Storage'
+import { getLabels } from '../../services/helpers'
+import { saveVocabularyNote } from '../../services/storageUtils'
+import VocabularyItemBuilder from '../../testing/VocabularyItemBuilder'
+import { renderWithStorageCache } from '../../testing/render'
+import VocabularyNoteSection from '../VocabularyNoteSection'
+
+describe('VocabularyNoteSection', () => {
+  const vocabularyItem = new VocabularyItemBuilder(1).build()[0]!
+  const { add, edit, delete: deleteLabel, placeholder, emptyError, confirm, save } = getLabels().notes
+
+  let storageCache: StorageCache
+
+  beforeEach(() => {
+    storageCache = StorageCache.createDummy()
+  })
+
+  const renderSection = () =>
+    renderWithStorageCache(storageCache, <VocabularyNoteSection vocabularyItem={vocabularyItem} />)
+
+  describe('when no note exists', () => {
+    it('should offer to add one', () => {
+      const { getByText } = renderSection()
+
+      expect(getByText(add)).toBeDefined()
+    })
+
+    it('should save a typed note', async () => {
+      const { getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText(add)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'Wie das englische Wort'))
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([
+        { wordId: vocabularyItem.id, text: 'Wie das englische Wort' },
+      ])
+    })
+
+    it('should not save a note that only contains whitespace', async () => {
+      const { getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText(add)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), '   '))
+      expect(getByText(emptyError)).toBeDefined()
+
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
+    })
+
+    it('should explain why saving is blocked after clearing what was typed', async () => {
+      const { getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText(add)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'ab'))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), ''))
+
+      expect(getByText(emptyError)).toBeDefined()
+    })
+
+    it('should not show an error before the user has typed', async () => {
+      const { getByText, queryByText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText(add)))
+
+      expect(queryByText(emptyError)).toBeNull()
+    })
+
+    it('should count an emoji as a single character', async () => {
+      const { getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText(add)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), '🚧🧱🔧'))
+
+      expect(getByText('3 / 500')).toBeDefined()
+    })
+
+    it('should not accept more than 500 characters', async () => {
+      const { getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText(add)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'a'.repeat(600)))
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')[0]!.text).toHaveLength(500)
+    })
+  })
+
+  describe('when a note exists', () => {
+    beforeEach(async () => {
+      await saveVocabularyNote(storageCache, vocabularyItem.id, 'Auf der Baustelle gelernt')
+    })
+
+    it('should show the note', () => {
+      const { getByText } = renderSection()
+
+      expect(getByText('Auf der Baustelle gelernt')).toBeDefined()
+    })
+
+    it('should open the editor when the note itself is tapped', async () => {
+      const { getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByText('Auf der Baustelle gelernt')))
+
+      expect(getByPlaceholderText(placeholder).props.value).toBe('Auf der Baustelle gelernt')
+    })
+
+    it('should open the editor pre-filled with the existing note', async () => {
+      const { getByLabelText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByLabelText(edit)))
+
+      expect(getByPlaceholderText(placeholder).props.value).toBe('Auf der Baustelle gelernt')
+    })
+
+    it('should replace the note when it is edited', async () => {
+      const { getByLabelText, getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByLabelText(edit)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), 'Im Praktikum gelernt'))
+      await act(async () => fireEvent.press(getByText(save)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([
+        { wordId: vocabularyItem.id, text: 'Im Praktikum gelernt' },
+      ])
+    })
+
+    it('should explain why saving is blocked when the note is cleared', async () => {
+      const { getByLabelText, getByText, getByPlaceholderText } = renderSection()
+
+      await act(async () => fireEvent.press(getByLabelText(edit)))
+      await act(async () => fireEvent.changeText(getByPlaceholderText(placeholder), ''))
+
+      expect(getByText(emptyError)).toBeDefined()
+    })
+
+    it('should keep the note until the deletion is confirmed', async () => {
+      const { getByLabelText, getByText } = renderSection()
+
+      await act(async () => fireEvent.press(getByLabelText(deleteLabel)))
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(1)
+
+      await act(async () => fireEvent.press(getByText(confirm)))
+
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
+    })
+  })
+})

--- a/src/components/text/uppercase.ts
+++ b/src/components/text/uppercase.ts
@@ -1,0 +1,6 @@
+import { css } from 'styled-components/native'
+
+export const uppercase = css`
+  letter-spacing: ${props => props.theme.fonts.capsLetterSpacing};
+  text-transform: uppercase;
+`

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -139,6 +139,11 @@ export type SimpleResult = (typeof SIMPLE_RESULTS)[keyof typeof SIMPLE_RESULTS]
 
 export type Favorite = VocabularyItemId
 
+export type VocabularyNote = {
+  wordId: VocabularyItemId
+  text: string
+}
+
 export type Answer = {
   word: string
   article: Article

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -329,7 +329,7 @@
     }
   },
   "notes": {
-    "sectionTitle": "Meine Notiz",
+    "heading": "Meine Notiz",
     "newNote": "Neue Notiz",
     "add": "Notiz hinzufügen",
     "edit": "Notiz bearbeiten",
@@ -337,9 +337,10 @@
     "languageHint": "Schreibe in jeder Sprache.",
     "placeholder": "Schreibe deine Notiz - Beispiel, Merksatz oder Übersetzung …",
     "emptyError": "Notiz kann nicht leer sein.",
-    "confirmDeletionTitle": "Notiz löschen?",
-    "confirmDeletion": "Möchtest du diese Notiz wirklich löschen? Das kann nicht rückgängig gemacht werden.",
-    "confirm": "Löschen",
+    "showMore": "Mehr anzeigen",
+    "deletionTitle": "Notiz löschen?",
+    "deletionWarning": "Möchtest du diese Notiz wirklich löschen? Das kann nicht rückgängig gemacht werden.",
+    "confirmDeletion": "Löschen",
     "cancel": "Abbrechen",
     "save": "Notiz speichern"
   },

--- a/src/constants/labels.json
+++ b/src/constants/labels.json
@@ -206,6 +206,7 @@
     },
     "back": "Zurück",
     "close": "Schließen",
+    "characterCount": "{{count}} von {{limit}} Zeichen",
     "plurals": "Plural",
     "noResults": "Es wurden leider keine Ergebnisse gefunden.",
     "error": {
@@ -326,6 +327,21 @@
       "clearJobs": "Clear selected jobs",
       "seedScreenshotData": "Load screenshot data"
     }
+  },
+  "notes": {
+    "sectionTitle": "Meine Notiz",
+    "newNote": "Neue Notiz",
+    "add": "Notiz hinzufügen",
+    "edit": "Notiz bearbeiten",
+    "delete": "Notiz löschen",
+    "languageHint": "Schreibe in jeder Sprache.",
+    "placeholder": "Schreibe deine Notiz - Beispiel, Merksatz oder Übersetzung …",
+    "emptyError": "Notiz kann nicht leer sein.",
+    "confirmDeletionTitle": "Notiz löschen?",
+    "confirmDeletion": "Möchtest du diese Notiz wirklich löschen? Das kann nicht rückgängig gemacht werden.",
+    "confirm": "Löschen",
+    "cancel": "Abbrechen",
+    "save": "Notiz speichern"
   },
   "sponsors": {
     "sponsors": "Unterstützer*innen",

--- a/src/hooks/useVocabularyNote.ts
+++ b/src/hooks/useVocabularyNote.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+import { VocabularyNote } from '../constants/data'
+import { VocabularyItemId } from '../models/VocabularyItem'
+import { getVocabularyNote } from '../services/storageUtils'
+import useStorage from './useStorage'
+
+type VocabularyNoteState = {
+  note: VocabularyNote | undefined
+  isEditorOpen: boolean
+  openEditor: () => void
+  closeEditor: () => void
+}
+
+const useVocabularyNote = (wordId: VocabularyItemId): VocabularyNoteState => {
+  const [vocabularyNotes] = useStorage('vocabularyNotes')
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false)
+
+  return {
+    note: getVocabularyNote(vocabularyNotes, wordId),
+    isEditorOpen,
+    openEditor: () => setIsEditorOpen(true),
+    closeEditor: () => setIsEditorOpen(false),
+  }
+}
+
+export default useVocabularyNote

--- a/src/routes/VocabularyDetailScreen.tsx
+++ b/src/routes/VocabularyDetailScreen.tsx
@@ -1,6 +1,7 @@
 import { RouteProp, useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { ReactElement, useCallback } from 'react'
+import { ScrollView } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
 import { PenIcon } from '../../assets/images'
@@ -46,7 +47,9 @@ const VocabularyDetailScreen = ({ route }: VocabularyDetailScreenProps): ReactEl
 
   return (
     <RouteWrapper>
-      <VocabularyDetail vocabularyItem={vocabularyItem} />
+      <ScrollView>
+        <VocabularyDetail vocabularyItem={vocabularyItem} />
+      </ScrollView>
     </RouteWrapper>
   )
 }

--- a/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
+++ b/src/routes/choice-exercises/__tests__/WordChoiceExerciseScreen.spec.tsx
@@ -48,6 +48,7 @@ jest.spyOn(Image, 'prefetch').mockResolvedValue(true)
 jest.mock('react-native/Libraries/LogBox/Data/LogBoxData')
 
 jest.mock('../../../services/storageUtils', () => ({
+  ...jest.requireActual('../../../services/storageUtils'),
   saveExerciseProgress: jest.fn().mockResolvedValue(undefined),
 }))
 
@@ -118,6 +119,18 @@ describe('WordChoiceExerciseScreen', () => {
 
     expect(getByText(getLabels().exercises.next)).toBeVisible()
     expect(queryByText(getLabels().exercises.tryLater)).toBeNull()
+  })
+
+  it('should offer to add a note once an answer was given, right or wrong', async () => {
+    const { getByText, queryByText } = renderScreen()
+    expect(queryByText(getLabels().notes.add)).toBeNull()
+
+    fireEvent.press(getByText('Auto'))
+
+    await waitFor(() => {
+      expect(getByText(getLabels().exercises.solution)).toBeVisible()
+    })
+    expect(getByText(getLabels().notes.add)).toBeVisible()
   })
 
   it('should show solution in the bottom sheet when answer is incorrect', async () => {

--- a/src/routes/choice-exercises/components/WordChoiceExercise.tsx
+++ b/src/routes/choice-exercises/components/WordChoiceExercise.tsx
@@ -251,6 +251,7 @@ const WordChoiceExercise = ({
       <WordResultIndicator
         isVisible={selectedAnswer !== null}
         isCorrect={result === SIMPLE_RESULTS.correct}
+        wordId={vocabularyItem.id}
         label={
           result === SIMPLE_RESULTS.correct
             ? getLabels().exercises.training.sentence.correct

--- a/src/routes/training/ImageTrainingScreen.tsx
+++ b/src/routes/training/ImageTrainingScreen.tsx
@@ -11,6 +11,7 @@ import CheatMode from '../../components/CheatMode'
 import ExerciseHeader from '../../components/ExerciseHeader'
 import RouteWrapper from '../../components/RouteWrapper'
 import ServerResponseHandler from '../../components/ServerResponseHandler'
+import VocabularyNotePreview from '../../components/VocabularyNotePreview'
 import { ContentText, ContentTextBold } from '../../components/text/Content'
 import {
   BUTTONS_THEME,
@@ -143,6 +144,10 @@ export const stateReducer = (state: State, action: Action): State => {
     }
   }
 }
+
+const NoteContainer = styled.View`
+  padding: ${props => props.theme.spacings.sm} ${props => props.theme.spacings.sm} 0;
+`
 
 const QuestionContainer = styled.View`
   flex-flow: row wrap;
@@ -280,6 +285,12 @@ const ImageTraining = ({ vocabularyItems, navigation, job }: ImageTrainingProps)
         </QuestionContainer>
 
         <ImageGrid items={imageGridItems} onPress={item => dispatch({ type: 'selectAnswer', key: item })} />
+
+        {isResolved && (
+          <NoteContainer>
+            <VocabularyNotePreview wordId={word.id} hasBorder />
+          </NoteContainer>
+        )}
       </TrainingExerciseContainer>
     </>
   )

--- a/src/routes/training/SentenceTrainingScreen.tsx
+++ b/src/routes/training/SentenceTrainingScreen.tsx
@@ -99,6 +99,7 @@ const ResultIndicator = ({
     <WordResultIndicator
       isVisible={isFinished}
       isCorrect={isCorrect}
+      wordId={currentSentence.vocabularyItemId}
       label={resultLabel}
       content={correctAnswerContent}
       button={button}

--- a/src/routes/training/SpeechTrainingScreen.tsx
+++ b/src/routes/training/SpeechTrainingScreen.tsx
@@ -410,6 +410,7 @@ const SpeechTraining = ({ vocabularyItems, navigation, job }: SpeechTrainingProp
       <WordResultIndicator
         isVisible={isSimpleResult}
         isCorrect={isCorrect}
+        wordId={currentWord.id}
         label={isCorrect ? labels.correct : labels.incorrect}
         content={wordContent}
         button={resultButton}

--- a/src/routes/training/__tests__/ImageTrainingScreen.spec.tsx
+++ b/src/routes/training/__tests__/ImageTrainingScreen.spec.tsx
@@ -105,6 +105,15 @@ describe('ImageTrainingScreen', () => {
     expect(queryByText(getLabels().exercises.training.image.whatIs, { exact: false })).toBeNull()
   })
 
+  it('should offer to add a note once the answer is resolved', async () => {
+    const { getAllByTestId, getByText, queryByText } = await renderScreenAndWaitForLoad()
+    expect(queryByText(getLabels().notes.add)).toBeNull()
+
+    fireEvent.press(getAllByTestId('imageOption')[0]!)
+
+    expect(getByText(getLabels().notes.add)).toBeVisible()
+  })
+
   it('should keep Skip button after selecting incorrect image', async () => {
     const { getAllByTestId, getByTestId, queryByText } = await renderScreenAndWaitForLoad()
 

--- a/src/routes/training/components/TrainingExerciseContainer.tsx
+++ b/src/routes/training/components/TrainingExerciseContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, ReactNode } from 'react'
 import styled from 'styled-components/native'
 
 import { Heading } from '../../../components/text/Heading'
@@ -27,7 +27,7 @@ const FooterContainer = styled.View`
 export type TrainingExerciseContainerProps = {
   title: string
   footer?: ReactElement
-  children: ReactElement[] | ReactElement | null
+  children: ReactNode
 }
 
 const TrainingExerciseContainer = ({ title, children, footer }: TrainingExerciseContainerProps): ReactElement => (

--- a/src/routes/vocabulary-detail-exercise/__tests__/VocabularyDetailScreen.spec.tsx
+++ b/src/routes/vocabulary-detail-exercise/__tests__/VocabularyDetailScreen.spec.tsx
@@ -57,4 +57,10 @@ describe('VocabularyDetailScreen', () => {
 
     expect(getByText(vocabularyItems[0]!.word)).toHaveStyle({ fontSize: FONT_SIZES.heading })
   })
+
+  it('should offer to add a note', () => {
+    const { getByText } = render(<VocabularyDetailExerciseScreen route={getRoute(0)} navigation={navigation} />)
+
+    expect(getByText(getLabels().notes.add)).toBeDefined()
+  })
 })

--- a/src/services/Storage.tsx
+++ b/src/services/Storage.tsx
@@ -2,7 +2,7 @@ import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import React, { createContext, ReactElement } from 'react'
 
-import { Favorite, Progress } from '../constants/data'
+import { Favorite, Progress, VocabularyNote } from '../constants/data'
 import useLoadAsync from '../hooks/useLoadAsync'
 import { UserVocabularyItem } from '../models/VocabularyItem'
 import { AnalyticsConsent } from './AnalyticsService'
@@ -29,6 +29,8 @@ export type Storage = {
   userVocabulary: UserVocabularyItem[]
   nextUserVocabularyId: number
   favorites: Favorite[]
+  // Personal notes on vocabulary items, only ever stored on the device
+  vocabularyNotes: VocabularyNote[]
   // Jobs that were started before the CMS migration and may have lost progress
   notMigratedSelectedJobs: number[]
   // A unique identifier for the installation
@@ -52,6 +54,7 @@ export const newDefaultStorage = (): Storage => ({
   userVocabulary: [],
   nextUserVocabularyId: 1,
   favorites: [],
+  vocabularyNotes: [],
   notMigratedSelectedJobs: [],
   installationId: null,
 })
@@ -71,6 +74,7 @@ export const storageKeys: Record<StorageKey, string> = {
   userVocabulary: 'userVocabulary',
   nextUserVocabularyId: 'userVocabularyNextId',
   favorites: 'favorites-2',
+  vocabularyNotes: 'vocabularyNotes',
   notMigratedSelectedJobs: 'notMigratedSelectedJobs',
   installationId: 'installationId',
 }
@@ -205,6 +209,7 @@ export const loadStorageCache = async (): Promise<StorageCache> => {
     userVocabulary: getStorageItem('userVocabulary'),
     nextUserVocabularyId: getStorageItem('nextUserVocabularyId'),
     favorites: getStorageItem('favorites'),
+    vocabularyNotes: getStorageItem('vocabularyNotes'),
     notMigratedSelectedJobs: getStorageItem('notMigratedSelectedJobs'),
     installationId: getStorageItem('installationId'),
   })

--- a/src/services/__tests__/storageUtils.spec.ts
+++ b/src/services/__tests__/storageUtils.spec.ts
@@ -13,9 +13,12 @@ import {
   addJobToNotMigrated,
   addUserVocabularyItem,
   deleteUserVocabularyItem,
+  deleteVocabularyNote,
   editUserVocabularyItem,
   FAVORITES_KEY_VERSION_0,
   getInstallationId,
+  getVocabularyNote,
+  saveVocabularyNote,
   pushSelectedJob,
   removeCustomDiscipline,
   removeFavorite,
@@ -616,6 +619,69 @@ describe('storageUtils', () => {
       await deleteUserVocabularyItem(storageCache, userVocabularyItems[0]!)
       const updatedUserVocabulary = storageCache.getItem('userVocabulary')
       expect(updatedUserVocabulary).toHaveLength(0)
+    })
+
+    it('should delete the note of a deleted userVocabularyItem', async () => {
+      await addUserVocabularyItem(storageCache, userVocabularyItems[0]!)
+      await saveVocabularyNote(storageCache, userVocabularyItems[0]!.id, 'Auf der Baustelle gelernt')
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(1)
+
+      await deleteUserVocabularyItem(storageCache, userVocabularyItems[0]!)
+
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
+    })
+  })
+
+  describe('vocabularyNotes', () => {
+    const vocabularyItems: VocabularyItem[] = new VocabularyItemBuilder(2).build()
+
+    it('should save a new note', async () => {
+      await saveVocabularyNote(storageCache, vocabularyItems[0]!.id, 'Klingt wie das englische Wort')
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([
+        { wordId: vocabularyItems[0]!.id, text: 'Klingt wie das englische Wort' },
+      ])
+    })
+
+    it('should update the existing note instead of adding a second one', async () => {
+      await saveVocabularyNote(storageCache, vocabularyItems[0]!.id, 'Erste Notiz')
+      await saveVocabularyNote(storageCache, vocabularyItems[0]!.id, 'Zweite Notiz')
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([
+        { wordId: vocabularyItems[0]!.id, text: 'Zweite Notiz' },
+      ])
+    })
+
+    it('should trim the note and reject a blank one', async () => {
+      await saveVocabularyNote(storageCache, vocabularyItems[0]!.id, '   \n  ')
+      expect(storageCache.getItem('vocabularyNotes')).toHaveLength(0)
+
+      await saveVocabularyNote(storageCache, vocabularyItems[0]!.id, '  Mit Leerzeichen  ')
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([
+        { wordId: vocabularyItems[0]!.id, text: 'Mit Leerzeichen' },
+      ])
+    })
+
+    it('should not confuse a standard word with a user created word of the same number', async () => {
+      const standardId = { type: VocabularyItemTypes.Standard, id: 1 } as const
+      const userCreatedId = { type: VocabularyItemTypes.UserCreated, index: 1 } as const
+      await saveVocabularyNote(storageCache, standardId, 'Notiz zum Lunes-Wort')
+      await saveVocabularyNote(storageCache, userCreatedId, 'Notiz zum eigenen Wort')
+
+      const vocabularyNotes = storageCache.getItem('vocabularyNotes')
+
+      expect(vocabularyNotes).toHaveLength(2)
+      expect(getVocabularyNote(vocabularyNotes, standardId)?.text).toBe('Notiz zum Lunes-Wort')
+      expect(getVocabularyNote(vocabularyNotes, userCreatedId)?.text).toBe('Notiz zum eigenen Wort')
+    })
+
+    it('should delete only the note of the given word', async () => {
+      await saveVocabularyNote(storageCache, vocabularyItems[0]!.id, 'Bleibt')
+      await saveVocabularyNote(storageCache, vocabularyItems[1]!.id, 'Wird gelöscht')
+
+      await deleteVocabularyNote(storageCache, vocabularyItems[1]!.id)
+
+      expect(storageCache.getItem('vocabularyNotes')).toEqual([{ wordId: vocabularyItems[0]!.id, text: 'Bleibt' }])
     })
   })
 

--- a/src/services/storageUtils.ts
+++ b/src/services/storageUtils.ts
@@ -1,7 +1,7 @@
 import { unlink } from '@dr.pogodin/react-native-fs'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
-import { StandardExerciseKey, Favorite } from '../constants/data'
+import { StandardExerciseKey, Favorite, VocabularyNote } from '../constants/data'
 import { StandardJobId } from '../models/Job'
 import { StandardUnitId } from '../models/Unit'
 import VocabularyItem, {
@@ -405,6 +405,40 @@ export const removeFavorite = async (storageCache: StorageCache, favorite: Favor
   await storageCache.setItem('favorites', newFavorites)
 }
 
+const notesExcludingWord = (vocabularyNotes: readonly VocabularyNote[], wordId: VocabularyItemId): VocabularyNote[] =>
+  vocabularyNotes.filter(note => !areVocabularyItemIdsEqual(note.wordId, wordId))
+
+export const getVocabularyNote = (
+  vocabularyNotes: readonly VocabularyNote[],
+  wordId: VocabularyItemId,
+): VocabularyNote | undefined => vocabularyNotes.find(note => areVocabularyItemIdsEqual(note.wordId, wordId))
+
+export const saveVocabularyNote = async (
+  storageCache: StorageCache,
+  wordId: VocabularyItemId,
+  text: string,
+): Promise<void> => {
+  const trimmedText = text.trim()
+  if (trimmedText.length === 0) {
+    return
+  }
+
+  const vocabularyNotes = storageCache.getItem('vocabularyNotes')
+  await storageCache.setItem('vocabularyNotes', [
+    ...notesExcludingWord(vocabularyNotes, wordId),
+    { wordId, text: trimmedText },
+  ])
+}
+
+export const deleteVocabularyNote = async (storageCache: StorageCache, wordId: VocabularyItemId): Promise<void> => {
+  const vocabularyNotes = storageCache.getItem('vocabularyNotes')
+  // deleteUserVocabularyItem also calls this for words that never had a note
+  if (getVocabularyNote(vocabularyNotes, wordId) === undefined) {
+    return
+  }
+  await storageCache.setItem('vocabularyNotes', notesExcludingWord(vocabularyNotes, wordId))
+}
+
 export const incrementNextUserVocabularyId = async (storageCache: StorageCache): Promise<UserVocabularyId> => {
   const nextId = storageCache.getItem('nextUserVocabularyId')
   await storageCache.setItem('nextUserVocabularyId', nextId + 1)
@@ -448,6 +482,7 @@ export const deleteUserVocabularyItem = async (
     }),
   )
   await removeFavorite(storageCache, userVocabularyItem.id)
+  await deleteVocabularyNote(storageCache, userVocabularyItem.id)
   await RepetitionService.fromStorageCache(storageCache).removeWordNodeCard(userVocabularyItem.id)
   await storageCache.setItem('userVocabulary', userVocabulary)
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR adds personal notes to vocabulary items. No backups yet, that will be a separate issue that we can work on later.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add a button to add a note
- Add an overlay to write a note
- Add a note (that can be expanded if it's longer than three lines)
- Add notes to storage
- Show the button or note in vocabulary cards
- Show the button or note in the word result overlay
- Show the button in the image training
- Some refactoring

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I had to rework the ModalSkeleton to not close on a tap anywhere on the screen but only on taps on the background. That changes behavior but I would say towards expected behavior, I wouldn't expect me tapping on something on a modal to close it.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open all the exercises and vocabulary screens, add notes, delete notes, play around

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1209

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
