### PR TITLE
1522: run LLM review on PR opening

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,6 +528,8 @@ jobs:
     llm-pr-review:
         docker:
             - image: cimg/python:3.11
+        environment:
+            LLM_REVIEW_PR_NUMBER: << pipeline.parameters.llm_review_pr_number >>
         resource_class: small
         steps:
             - checkout
@@ -788,6 +790,9 @@ jobs:
                 root: .
             - notify
 parameters:
+    llm_review_pr_number:
+        default: ""
+        type: string
     run_browserstack_delivery:
         default: false
         type: boolean
@@ -802,6 +807,9 @@ parameters:
             - skip
         type: enum
     run_dev_delivery:
+        default: false
+        type: boolean
+    run_llm_review:
         default: false
         type: boolean
     run_promote:
@@ -846,11 +854,6 @@ workflows:
             - check:
                 context:
                     - mattermost
-            - llm-pr-review:
-                context:
-                    - mattermost
-                    - deliverino
-                    - digitalfabrik-llm-api
         when:
             and:
                 - << pipeline.parameters.run_commit >>
@@ -945,6 +948,14 @@ workflows:
                     - deliver_android
                     - deliver_ios
         when: << pipeline.parameters.run_dev_delivery >>
+    llm_review:
+        jobs:
+            - llm-pr-review:
+                context:
+                    - mattermost
+                    - deliverino
+                    - digitalfabrik-llm-api
+        when: << pipeline.parameters.run_llm_review >>
     promote:
         jobs:
             - promote_android:

--- a/.circleci/scripts/llm-pr-review.py
+++ b/.circleci/scripts/llm-pr-review.py
@@ -11,12 +11,16 @@ rejects, and it never changes labels itself.
 This script always exits 0 so that LLM or network failures never block
 a merge. Errors are printed to stderr and visible in the CI log.
 
+Reviews are triggered by the GitHub Actions workflow in
+.github/workflows/llm-pr-review.yml, which reacts to the pull_request event and
+starts a review-only CircleCI pipeline.
+
 Required environment variables (injected by CircleCI):
-  CIRCLE_PULL_REQUEST      URL of the pull request associated with this
-                           build (e.g. https://github.com/org/repo/pull/123),
-                           only set when the current branch has an open PR.
-                           Not populated for forked-PR builds unless secrets
-                           are explicitly passed to fork builds.
+  LLM_REVIEW_PR_NUMBER     Number of the pull request to review, set from the
+                           `llm_review_pr_number` pipeline parameter by the
+                           GitHub Actions workflow. Empty on any pipeline that
+                           workflow did not start, in which case the review is
+                           skipped.
   CIRCLE_PROJECT_USERNAME  Repository owner (org or user)
   CIRCLE_PROJECT_REPONAME  Repository name
 
@@ -176,14 +180,6 @@ def warn(message):
     print(f"Warning: {message}", file=sys.stderr)
 
 
-def pr_number_from_url(pull_request_url):
-    """
-    Extracts the PR number from a CIRCLE_PULL_REQUEST URL, e.g.
-    "https://github.com/org/repo/pull/123" -> "123".
-    """
-    return pull_request_url.rstrip("/").rsplit("/", 1)[-1]
-
-
 def path_from_diff_header(header_line):
     """
     Extracts the file path from a "diff --git a/... b/..." header line,
@@ -246,18 +242,19 @@ def compress_diff(diff_text):
 
 def main():
     # -------------------------------------------------------------------------
-    # Step 0: Only act on builds associated with an open pull request
+    # Step 0: Determine which pull request to review
     # -------------------------------------------------------------------------
 
-    pull_request_url = os.environ.get("CIRCLE_PULL_REQUEST", "")
-    if not pull_request_url:
+    pr_number = os.environ.get("LLM_REVIEW_PR_NUMBER", "").strip()
+    if not pr_number:
         print(
-            "Skipping LLM review: no open pull request is associated with this "
-            "branch (CIRCLE_PULL_REQUEST is not set)."
+            "Skipping LLM review: LLM_REVIEW_PR_NUMBER is empty, so this "
+            "pipeline was not started by the review trigger in "
+            ".github/workflows/llm-pr-review.yml."
         )
         return
 
-    pr_number = pr_number_from_url(pull_request_url)
+    print(f"Reviewing PR #{pr_number}.")
 
     # -------------------------------------------------------------------------
     # Step 1: Read environment

--- a/.circleci/src/@common.yml
+++ b/.circleci/src/@common.yml
@@ -25,3 +25,11 @@ parameters:
   run_update_screenshots:
     default: false
     type: boolean
+
+  run_llm_review:
+    default: false
+    type: boolean
+
+  llm_review_pr_number:
+    default: ''
+    type: string

--- a/.circleci/src/jobs/llm-pr-review.yml
+++ b/.circleci/src/jobs/llm-pr-review.yml
@@ -1,6 +1,8 @@
 docker:
   - image: cimg/python:3.11
 resource_class: small
+environment:
+  LLM_REVIEW_PR_NUMBER: << pipeline.parameters.llm_review_pr_number >>
 steps:
   - checkout
   - run:

--- a/.circleci/src/workflows/commit.yml
+++ b/.circleci/src/workflows/commit.yml
@@ -8,8 +8,3 @@ jobs:
   - check:
       context:
         - mattermost
-  - llm-pr-review:
-      context:
-        - mattermost
-        - deliverino
-        - digitalfabrik-llm-api

--- a/.circleci/src/workflows/llm_review.yml
+++ b/.circleci/src/workflows/llm_review.yml
@@ -1,0 +1,7 @@
+when: << pipeline.parameters.run_llm_review >>
+jobs:
+  - llm-pr-review:
+      context:
+        - mattermost
+        - deliverino
+        - digitalfabrik-llm-api

--- a/.github/workflows/llm-pr-review.yml
+++ b/.github/workflows/llm-pr-review.yml
@@ -1,0 +1,47 @@
+name: LLM PR review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: llm-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger-circleci:
+    name: Trigger the LLM review pipeline on CircleCI
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI pipeline
+        env:
+          CIRCLECI_API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "${CIRCLECI_API_TOKEN}" ]; then
+            echo "::error::The CIRCLECI_API_TOKEN repository secret is not set."
+            exit 1
+          fi
+
+          BODY=$(jq -n \
+            --arg branch "${BRANCH}" \
+            --arg pr_number "${PR_NUMBER}" \
+            '{
+              branch: $branch,
+              parameters: {
+                run_commit: false,
+                run_llm_review: true,
+                llm_review_pr_number: $pr_number
+              }
+            }')
+
+          echo "Triggering LLM review for PR #${PR_NUMBER} on branch ${BRANCH} ..."
+          curl --fail-with-body --silent --show-error \
+            --url "https://circleci.com/api/v2/project/gh/${GITHUB_REPOSITORY}/pipeline" \
+            --header "Circle-Token: ${CIRCLECI_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "${BODY}"

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -4,6 +4,7 @@
 
 - [Deliver a new release by triggering the CI](#triggering-a-delivery-using-the-ci)
 - [Workflows](#workflows)
+- [LLM Pull Request Review](#llm-pull-request-review)
 - [Services](#services)
 - [Fastlane](#fastlane)
 
@@ -51,12 +52,31 @@ Several workflows exist for different purposes:
 - **dev_delivery**: [Manually triggerable](#triggering-a-delivery-using-the-ci) workflow which delivers builds to development/beta.
 - **promote**: [Manually triggerable](#triggering-a-delivery-using-the-ci) workflow which promotes latest beta to production.
 - **browserstack_delivery**: [Manually triggerable](#triggering-a-delivery-using-the-ci) workflow to build the ios and android app and upload it to browserstack.
+- **llm_review**: Runs the LLM-based pull request review. [Triggered from GitHub Actions](#llm-pull-request-review), not by a push.
 
 ## UI/UX workflow
 
 To simplify the testing process for the UI/UX team, we use the **browserstack_delivery** workflow.
 Start the **browserstack_delivery** workflow on any PR that should be tested on browserstack.
 After completion, the deliverino bot will post a comment with links to the browserstack builds.
+
+## LLM Pull Request Review
+
+The **llm_review** workflow posts an automated review comment on pull requests.
+CircleCI cannot subscribe to GitHub's `pull_request` event, so the GitHub Actions
+workflow [`.github/workflows/llm-pr-review.yml`](../.github/workflows/llm-pr-review.yml)
+reacts to that event and triggers the workflow through the CircleCI API.
+
+It runs when a pull request is opened, reopened, marked ready for review, or receives a
+push. Pull requests from forks are skipped, because they get no secrets. The trigger
+passes three pipeline parameters:
+
+- `run_llm_review`: `true`, which selects the workflow.
+- `llm_review_pr_number`: the number of the pull request to review.
+- `run_commit`: `false`, so the **commit** workflow does not run a second time (its default is `true`).
+
+The review only comments — it never approves, rejects or changes labels — and the script
+always exits successfully, so an LLM or network failure can never block a merge.
 
 ## Services
 
@@ -102,6 +122,7 @@ Lanes for Android live in [../android/fastlane](../android/fastlane) and for iOS
 | Variable               | Description                    | Where do I get it from? | Reference                                                                                  |                                                  |
 | ---------------------- | ------------------------------ | ----------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ |
 | DELIVERINO_PRIVATE_KEY | Base64 encoded PEM private key | Password Manager        | [Deliverino Settings](https://github.com/organizations/Integreat/settings/apps/deliverino) | [Deliverino](https://github.com/apps/deliverino) |
+| CIRCLECI_API_TOKEN     | CircleCI Personal API Token, stored as a **GitHub** repository secret. Used by the GitHub Actions workflow to trigger the [llm_review](#llm-pull-request-review) workflow. | [CircleCI user settings](https://app.circleci.com/settings/user/tokens) | [Managing API tokens](https://circleci.com/docs/managing-api-tokens/) | |
 
 ### Android Variables
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -119,10 +119,10 @@ Lanes for Android live in [../android/fastlane](../android/fastlane) and for iOS
 
 ## Environment Variables and Dependencies
 
-| Variable               | Description                    | Where do I get it from? | Reference                                                                                  |                                                  |
-| ---------------------- | ------------------------------ | ----------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ |
-| DELIVERINO_PRIVATE_KEY | Base64 encoded PEM private key | Password Manager        | [Deliverino Settings](https://github.com/organizations/Integreat/settings/apps/deliverino) | [Deliverino](https://github.com/apps/deliverino) |
-| CIRCLECI_API_TOKEN     | CircleCI Personal API Token, stored as a **GitHub** repository secret. Used by the GitHub Actions workflow to trigger the [llm_review](#llm-pull-request-review) workflow. | [CircleCI user settings](https://app.circleci.com/settings/user/tokens) | [Managing API tokens](https://circleci.com/docs/managing-api-tokens/) | |
+| Variable               | Description                                                                                                                                                                | Where do I get it from?                                                 | Reference                                                                                  |                                                  |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| DELIVERINO_PRIVATE_KEY | Base64 encoded PEM private key                                                                                                                                             | Password Manager                                                        | [Deliverino Settings](https://github.com/organizations/Integreat/settings/apps/deliverino) | [Deliverino](https://github.com/apps/deliverino) |
+| CIRCLECI_API_TOKEN     | CircleCI Personal API Token, stored as a **GitHub** repository secret. Used by the GitHub Actions workflow to trigger the [llm_review](#llm-pull-request-review) workflow. | [CircleCI user settings](https://app.circleci.com/settings/user/tokens) | [Managing API tokens](https://circleci.com/docs/managing-api-tokens/)                      |                                                  |
 
 ### Android Variables
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR changes the trigger for the LLM review. So far, it had been on pushes on a branch, but only executed if there is a PR. We often open PRs and don't have any additional pushes, so that was a problem. This now changes the trigger to be when a PR is opened or updated.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Create a GitHub action that triggers the LLM review workflow
- Update the documentation

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- We have to add a CircleCI token to GitHub; I'm working getting that to not be associated with my personal account...

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See that the LLM review workflow ran immediately after opening the [CMS PR](https://github.com/digitalfabrik/lunes-cms/pull/979)?

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1522 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/lunes-app/blob/main/docs/conventions.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
